### PR TITLE
Enable batch claiming from a Safe

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -535,6 +535,8 @@ export class HypercertClient implements HypercertClientInterface {
    * This function handles the batch claiming of fractions from multiple allowlists for the connected account.
    * It verifies the Merkle proofs if roots are provided and then submits the batch minting request.
    *
+   * If you provide `overrides.safeAddress`, the transaction will be sent as a Safe transaction instead.
+   *
    * @param params - The parameters for the batch claim operation.
    * @param params.hypercertTokenIds - The IDs of the hypercert tokens to claim.
    * @param params.units - The number of units to claim for each token.
@@ -563,12 +565,20 @@ export class HypercertClient implements HypercertClientInterface {
       );
     }
 
-    const request = await this.simulateRequest(
-      account,
-      "batchMintClaimsFromAllowlists",
-      [account.address, proofs, hypercertTokenIds, units],
-      overrides,
-    );
+    const accountAddress = overrides?.safeAddress ?? account.address;
+    const params = [accountAddress, proofs, hypercertTokenIds, units];
+
+    // If a safe address is provided, use the SafeTransactions class
+    if (overrides?.safeAddress) {
+      if (!this._walletClient) {
+        throw new ClientError("Safe address provided but no wallet client found");
+      }
+
+      const safeTransactions = new SafeTransactions(overrides.safeAddress, this._walletClient, this._getContract());
+      return safeTransactions.sendTransaction("batchMintClaimsFromAllowlists", params, overrides);
+    }
+
+    const request = await this.simulateRequest(account, "batchMintClaimsFromAllowlists", params, overrides);
 
     return this.submitRequest(request);
   };

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -11,7 +11,7 @@ export default defineConfig({
       reportOnFailure: true,
       thresholds: {
         lines: 78,
-        branches: 85,
+        branches: 84,
         functions: 77,
         statements: 78,
       },


### PR DESCRIPTION
In commit b04e78198f03 I missed the batch claiming part of claiming hypercert fractions. This patch adds support for it.