### PR TITLE
rename SDK in readme to Hypercerts instead of Hypercert

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Hypercert SDK
+# Hypercerts SDK
 
 ## Quickstart Guide
 


### PR DESCRIPTION
rename SDK to Hypercerts instead of Hypercert