### PR TITLE
ci: allow Hypercerts Release Bot GitHub App to bypass branch protection

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,8 +14,19 @@ jobs:
       id-token: write
 
     steps:
-      - uses: actions/checkout@v4
+      - name: Generate Release Bot App Token
+        id: generate-token
+        uses: actions/create-github-app-token@v1
         with:
+          app-id: ${{ secrets.RELEASE_BOT_APP_ID }}
+          private-key: ${{ secrets.RELEASE_BOT_APP_PRIVATE_KEY }}
+
+      - uses: actions/checkout@v6
+        with:
+          # Persist releasebot app credentials to ensure that the push
+          # below can bypass branch protection rules
+          token: ${{ steps.generate-token.outputs.token }}
+          persist-credentials: true
           fetch-depth: 0
 
       # Branch validation: Only allow develop (beta) or main (stable)


### PR DESCRIPTION
The release workflow needs to be able to push commits and tags directly to the repo when making a beta release.  The default github-actions[bot] identity can't be added to branch protection ruleset bypass lists, so a new Release Bot GitHub App has been created which should facilitate this bypass mechanism.