### PR TITLE
fix: remove outdated references to `packages/lexicon`

### DIFF
--- a/.changeset/fix-package-publishing-files.md
+++ b/.changeset/fix-package-publishing-files.md
@@ -1,7 +1,6 @@
 ---
 "@hypercerts-org/sdk-core": patch
 "@hypercerts-org/sdk-react": patch
-"@hypercerts-org/lexicon": patch
 ---
 
 Configure npm publishing to exclude source code and development files. Packages now only include the compiled `dist/`

--- a/.changeset/fix-sds-endpoints-and-nsids.md
+++ b/.changeset/fix-sds-endpoints-and-nsids.md
@@ -1,6 +1,5 @@
 ---
 "@hypercerts-org/sdk-core": patch
-"@hypercerts-org/lexicon": patch
 "@hypercerts-org/sdk-react": patch
 ---
 

--- a/.changeset/initial-lexicon-release.md
+++ b/.changeset/initial-lexicon-release.md
@@ -1,5 +1,0 @@
----
-"@hypercerts-org/lexicon": minor
----
-
-Initial release of lexicon package with ATProto lexicon definitions and TypeScript types for Hypercerts protocol


### PR DESCRIPTION
`packages/lexicon` has been removed, but there were still unreleased changesets referring to it.  This breaks the `changeset version` part of the release workflow, so remove those references.