### PR TITLE
chore: manually bump versions to v0.10.0-beta.1

### DIFF
--- a/packages/sdk-core/package.json
+++ b/packages/sdk-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hypercerts-org/sdk-core",
-  "version": "0.10.0-beta.0",
+  "version": "0.10.0-beta.1",
   "description": "Framework-agnostic ATProto SDK core for authentication, repository operations, and lexicon management",
   "main": "dist/index.cjs",
   "repository": {

--- a/packages/sdk-react/package.json
+++ b/packages/sdk-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hypercerts-org/sdk-react",
-  "version": "0.10.0-beta.0",
+  "version": "0.10.0-beta.1",
   "description": "React hooks and components for the Hypercerts ATProto SDK",
   "type": "module",
   "main": "dist/index.cjs",


### PR DESCRIPTION
The last time `changeset versions` was run, it was from the wrong `initialVersions` so we had to manually correct the versions in 0371b2bb, but they were incorrectly set to `beta.0` rather than `beta.1`.  So fix them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * SDK packages updated to version 0.10.0-beta.1 for core and React distributions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->