### PR TITLE
Fix: Remove validation from hypercert get call

### DIFF
--- a/.changeset/fix-remove-validation-from-hypercert-get.md
+++ b/.changeset/fix-remove-validation-from-hypercert-get.md
@@ -1,0 +1,5 @@
+---
+"@hypercerts-org/sdk-core": patch
+---
+
+Remove validation from hypercert.get

--- a/packages/sdk-core/README.md
+++ b/packages/sdk-core/README.md
@@ -20,6 +20,11 @@ const sdk = createATProtoSDK({
     jwksUri: "https://your-app.com/jwks.json",
     jwkPrivate: process.env.ATPROTO_JWK_PRIVATE!,
   },
+  // set up with your pds url.
+  // entryway doesn't work for this. Has to be a PDS URL.
+  servers: {
+    pds: "https://pds-eu-west4.test.certified.app",
+  },
 });
 
 // 2. Authenticate user

--- a/packages/sdk-core/src/repository/HypercertOperationsImpl.ts
+++ b/packages/sdk-core/src/repository/HypercertOperationsImpl.ts
@@ -638,12 +638,6 @@ export class HypercertOperationsImpl extends EventEmitter<HypercertEvents> imple
         throw new NetworkError("Failed to get hypercert");
       }
 
-      // Validate with lexicon (more lenient - doesn't require $type)
-      const validation = validate(result.data.value, HYPERCERT_COLLECTIONS.CLAIM, "main", false);
-      if (!validation.success) {
-        throw new ValidationError(`Invalid hypercert record format: ${validation.error?.message}`);
-      }
-
       return {
         uri: result.data.uri,
         cid: result.data.cid ?? "",


### PR DESCRIPTION
Remove the lexicon validation from `repo.hypercerts.get(uri)` call because the lexicon expects creation params with `$type` for the image. But Atproto returns a BlobRef instead of what the lexicon expects.

Also I think it doesnt really make sense to run validation on a get call when we've technically already run it on creation. It runs successfully on the `list` call since theres no validation and it should be uniform.

Updated the docs to reflect the requirement of PDS url in sdk config.

Fixes #78 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Removed a post-fetch validation step from hypercert retrieval to streamline successful fetch paths.

* **Documentation**
  * Updated SDK Quick Start to include an explicit PDS server configuration example and guidance for using a dedicated PDS URL.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->