### PR TITLE
fix: update create org params to match procedure

### DIFF
--- a/.changeset/fix-create-org-params.md
+++ b/.changeset/fix-create-org-params.md
@@ -1,0 +1,7 @@
+---
+"@hypercerts-org/sdk-core": minor
+---
+
+Update the params for create organization. Created a separate interface for it. Changed the params from handle to
+handlePrefix as expected by the actual `sds.organizations.create` procedure call. Added validation to check the required
+parameters in the call

--- a/packages/sdk-core/src/repository/CollaboratorOperationsImpl.ts
+++ b/packages/sdk-core/src/repository/CollaboratorOperationsImpl.ts
@@ -9,8 +9,8 @@
 
 import { NetworkError } from "../core/errors.js";
 import type { CollaboratorPermissions, Session } from "../core/types.js";
-import type { CollaboratorOperations } from "./interfaces.js";
-import type { RepositoryRole, RepositoryAccessGrant } from "./types.js";
+import type { CollaboratorOperations, GrantAccessParams } from "./interfaces.js";
+import type { RepositoryAccessGrant, RepositoryRole } from "./types.js";
 
 /**
  * Implementation of collaborator operations for SDS access control.
@@ -156,7 +156,7 @@ export class CollaboratorOperationsImpl implements CollaboratorOperations {
    * });
    * ```
    */
-  async grant(params: { userDid: string; role: RepositoryRole }): Promise<void> {
+  async grant(params: GrantAccessParams): Promise<void> {
     const permissions = this.roleToPermissions(params.role);
 
     const response = await this.session.fetchHandler(`${this.serverUrl}/xrpc/com.sds.repo.grantAccess`, {

--- a/packages/sdk-core/src/repository/OrganizationOperationsImpl.ts
+++ b/packages/sdk-core/src/repository/OrganizationOperationsImpl.ts
@@ -7,10 +7,10 @@
  * @packageDocumentation
  */
 
-import { NetworkError } from "../core/errors.js";
+import { NetworkError, ValidationError } from "../core/errors.js";
 import type { CollaboratorPermissions, Session } from "../core/types.js";
 import type { LoggerInterface } from "../core/interfaces.js";
-import type { OrganizationOperations } from "./interfaces.js";
+import type { CreateOrganizationParams, OrganizationOperations } from "./interfaces.js";
 import type { OrganizationInfo } from "./types.js";
 
 /**
@@ -108,10 +108,17 @@ export class OrganizationOperationsImpl implements OrganizationOperations {
    * });
    * ```
    */
-  async create(params: { name: string; description?: string; handle?: string }): Promise<OrganizationInfo> {
+  async create(params: CreateOrganizationParams): Promise<OrganizationInfo> {
     const userDid = this.session.did || this.session.sub;
     if (!userDid) {
       throw new NetworkError("No authenticated user found");
+    }
+
+    if (!params.handlePrefix) {
+      throw new ValidationError("Missing handlePrefix");
+    }
+    if (!params.name) {
+      throw new ValidationError("Missing name");
     }
 
     const response = await this.session.fetchHandler(`${this.serverUrl}/xrpc/com.sds.organization.create`, {

--- a/packages/sdk-core/src/repository/interfaces.ts
+++ b/packages/sdk-core/src/repository/interfaces.ts
@@ -89,6 +89,7 @@ import type {
  * };
  * ```
  */
+
 export interface CreateHypercertParams {
   /**
    * Title of the hypercert.
@@ -243,6 +244,23 @@ export interface CreateHypercertParams {
    * record creation, attachment linking, etc.).
    */
   onProgress?: (step: ProgressStep) => void;
+}
+
+export interface CreateOrganizationParams {
+  /**
+   * Name of the organization
+   */
+  name: string;
+  /**
+   * The handle of the organization without attaching the SDS domain
+   *
+   * @example: "gainforest" for "gainforest.sds.hypercerts.org"
+   */
+  handlePrefix: string;
+  /**
+   * Optional description of the organization
+   */
+  description?: string;
 }
 
 /**
@@ -798,6 +816,17 @@ export interface HypercertOperations extends EventEmitter<HypercertEvents> {
  * await repo.collaborators.revoke({ userDid: "did:plc:former-user" });
  * ```
  */
+
+export interface GrantAccessParams {
+  /**
+   * DID of the user to grant access to
+   */
+  userDid: string;
+  /**
+   * Role to assign
+   */
+  role: RepositoryRole;
+}
 export interface CollaboratorOperations {
   /**
    * Grants repository access to a user.
@@ -806,7 +835,7 @@ export interface CollaboratorOperations {
    * @param params.userDid - DID of the user to grant access to
    * @param params.role - Role to assign
    */
-  grant(params: { userDid: string; role: RepositoryRole }): Promise<void>;
+  grant(params: GrantAccessParams): Promise<void>;
 
   /**
    * Revokes repository access from a user.
@@ -888,13 +917,10 @@ export interface OrganizationOperations {
   /**
    * Creates a new organization.
    *
-   * @param params - Organization parameters
-   * @param params.name - Organization name
-   * @param params.description - Optional description
-   * @param params.handle - Optional custom handle
+   * @param params - Organization creation parameters
    * @returns Promise resolving to organization info
    */
-  create(params: { name: string; description?: string; handle?: string }): Promise<OrganizationInfo>;
+  create(params: CreateOrganizationParams): Promise<OrganizationInfo>;
 
   /**
    * Gets an organization by DID.

--- a/packages/sdk-core/tests/repository/OrganizationOperationsImpl.test.ts
+++ b/packages/sdk-core/tests/repository/OrganizationOperationsImpl.test.ts
@@ -29,7 +29,7 @@ describe("OrganizationOperationsImpl", () => {
       const result = await orgOps.create({
         name: "My Organization",
         description: "A test organization",
-        handle: "myorg",
+        handlePrefix: "myorg",
       });
 
       expect(result.did).toBe("did:plc:neworg123");
@@ -57,7 +57,7 @@ describe("OrganizationOperationsImpl", () => {
         }),
       });
 
-      const result = await orgOps.create({ name: "Org" });
+      const result = await orgOps.create({ name: "Org", handlePrefix: "test" });
 
       expect(result.name).toBe("Org");
       expect(result.createdAt).toBeDefined(); // Should default to current time
@@ -69,7 +69,7 @@ describe("OrganizationOperationsImpl", () => {
         statusText: "Conflict",
       });
 
-      await expect(orgOps.create({ name: "Test Org" })).rejects.toThrow(NetworkError);
+      await expect(orgOps.create({ name: "Test Org", handlePrefix: "test" })).rejects.toThrow(NetworkError);
     });
   });
 

--- a/packages/sdk-react/src/types.ts
+++ b/packages/sdk-react/src/types.ts
@@ -205,9 +205,20 @@ export interface UseProfileResult {
  * Parameters for creating an organization.
  */
 export interface CreateOrganizationParams {
+  /**
+   * Name of the organization
+   */
   name: string;
+  /**
+   * The handle of the organization without attaching the SDS domain
+   *
+   * @example: "gainforest" for "gainforest.sds.hypercerts.org"
+   */
+  handlePrefix: string;
+  /**
+   * Optional description of the organization
+   */
   description?: string;
-  handle?: string;
 }
 
 /**


### PR DESCRIPTION
The actual `sds.organizations.create` requires the params to be:

```
{
   handlePrefix: string,
   name: string,
   description?: string
}
```

However the sdk expected the params as `handle` rather than `handlePrefix`. It also wasn't upto date with the sds code where `handlePrefix` is now a requirement and not optional.

Also added in validation to check for `handlePrefix` and `name` and also updated test cases to match the new params.

~~The current setup for `repo.collaborators.grant` expects only `userDid` and `role`. However there is no option to override the `repoDid` or provide it. Instead it uses the default `this.repoDid` which is just the `session.did`. This means that we cant choose which repo/org we want to give the actual perms to.~~
I was using the sdk wrong so each `repository` class needs to be scoped for a `targetDid` rather than sending `repoDid` through params. Removed all code related to that

Updated the test cases for this and the params as well

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added CreateOrganizationParams and CreateHypercertParams to the SDK public API.
  * Collaborator grant accepts a structured parameter and supports an optional repo target.

* **Breaking Changes**
  * Organization creation parameter renamed from handle to handlePrefix.
  * handlePrefix is now required.

* **Bug Fixes**
  * Runtime validation enforces name and handlePrefix when creating organizations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->