### PR TITLE
Fix: Adding evidence using the SDK

### DIFF
--- a/.changeset/fix-add-evidence.md
+++ b/.changeset/fix-add-evidence.md
@@ -1,0 +1,6 @@
+---
+"@hypercerts-org/sdk-core": minor
+---
+
+Update the body of addEvidence parameters so that $type and uri and subject is constructed in the sdk. Evidence is also
+saved as a record on its own now instead of it being added to the hypercert.

--- a/.changeset/fix-add-evidence.md
+++ b/.changeset/fix-add-evidence.md
@@ -2,5 +2,16 @@
 "@hypercerts-org/sdk-core": minor
 ---
 
-Update the body of addEvidence parameters so that $type and uri and subject is constructed in the sdk. Evidence is also
-saved as a record on its own now instead of it being added to the hypercert.
+Evidence records are now created separately instead of being embedded inline in hypercerts
+
+- `create()` now calls `addEvidence()` for each evidence item using `Promise.all()` for parallel creation
+- Remove inline evidence embedding from hypercert records
+- Add `evidenceUris?: string[]` to `CreateHypercertResult` interface
+- Add `createEvidenceWithProgress()` helper method with "addEvidence" progress tracking
+- `addEvidence()` SDK constructs `$type`, `createdAt`, and `subject` fields internally
+
+**Breaking Changes:**
+
+- Evidence is no longer embedded in the hypercert record - use `result.evidenceUris` to access evidence record URIs
+- `addEvidence()` now accepts a single `CreateHypercertEvidenceParams` object instead of
+  `(uri: string, evidence: HypercertEvidence[])`

--- a/packages/sdk-core/src/index.ts
+++ b/packages/sdk-core/src/index.ts
@@ -36,6 +36,8 @@ export type {
   OrganizationOperations,
   CreateHypercertParams,
   CreateHypercertResult,
+  CreateHypercertEvidenceParams,
+  CreateOrganizationParams,
 } from "./repository/interfaces.js";
 
 // ============================================================================

--- a/packages/sdk-core/src/repository/HypercertOperationsImpl.ts
+++ b/packages/sdk-core/src/repository/HypercertOperationsImpl.ts
@@ -9,29 +9,30 @@
  */
 
 import type { Agent } from "@atproto/api";
+import { validate } from "@hypercerts-org/lexicon";
 import { EventEmitter } from "eventemitter3";
 import { NetworkError, ValidationError } from "../core/errors.js";
 import type { LoggerInterface } from "../core/interfaces.js";
-import { validate } from "@hypercerts-org/lexicon";
 import {
   HYPERCERT_COLLECTIONS,
-  type JsonBlobRef,
-  type HypercertEvidence,
   type HypercertClaim,
-  type HypercertRights,
-  type HypercertContribution,
-  type HypercertMeasurement,
-  type HypercertEvaluation,
   type HypercertCollection,
+  type HypercertContribution,
+  type HypercertEvaluation,
+  type HypercertEvidence,
   type HypercertLocation,
+  type HypercertMeasurement,
+  type HypercertRights,
+  type JsonBlobRef,
 } from "../services/hypercerts/types.js";
 import type {
-  HypercertOperations,
-  HypercertEvents,
+  CreateHypercertEvidenceParams,
   CreateHypercertParams,
   CreateHypercertResult,
+  HypercertEvents,
+  HypercertOperations,
 } from "./interfaces.js";
-import type { CreateResult, UpdateResult, PaginatedList, ListParams, ProgressStep } from "./types.js";
+import type { CreateResult, ListParams, PaginatedList, ProgressStep, UpdateResult } from "./types.js";
 
 /**
  * Implementation of high-level hypercert operations.
@@ -856,38 +857,64 @@ export class HypercertOperationsImpl extends EventEmitter<HypercertEvents> imple
   }
 
   /**
-   * Adds evidence to an existing hypercert.
+   * Adds evidence to any subject via the subject ref.
    *
-   * @param hypercertUri - AT-URI of the hypercert
-   * @param evidence - Array of evidence items to add
+   * @param evidence - HypercertEvidenceInput
    * @returns Promise resolving to update result
    * @throws {@link ValidationError} if validation fails
    * @throws {@link NetworkError} if the operation fails
-   *
-   * @remarks
-   * Evidence is appended to existing evidence, not replaced.
-   *
-   * @example
-   * ```typescript
-   * await repo.hypercerts.addEvidence(hypercertUri, [
-   *   { uri: "https://example.com/report.pdf", description: "Impact report" },
-   *   { uri: "https://example.com/data.csv", description: "Raw data" },
-   * ]);
-   * ```
    */
-  async addEvidence(hypercertUri: string, evidence: HypercertEvidence[]): Promise<UpdateResult> {
+  async addEvidence(evidence: CreateHypercertEvidenceParams): Promise<UpdateResult> {
     try {
-      const existing = await this.get(hypercertUri);
-      const existingEvidence = (existing.record.evidence as HypercertEvidence[]) || [];
-      const updatedEvidence = [...existingEvidence, ...evidence];
+      const { subjectUri, content, ...rest } = evidence;
+      const subject = await this.get(subjectUri);
+      const createdAt = new Date().toISOString();
 
-      const result = await this.update({
-        uri: hypercertUri,
-        updates: { evidence: updatedEvidence },
+      let evidenceContent: HypercertEvidence["content"];
+      if (typeof content === "string") {
+        evidenceContent = {
+          $type: "org.hypercerts.defs#uri",
+          uri: content,
+        };
+      } else {
+        // Handle Blob upload
+        const arrayBuffer = await content.arrayBuffer();
+        const uint8Array = new Uint8Array(arrayBuffer);
+        const uploadResult = await this.agent.com.atproto.repo.uploadBlob(uint8Array, {
+          encoding: content.type || "application/octet-stream",
+        });
+
+        if (!uploadResult.success) {
+          throw new NetworkError("Failed to upload evidence blob");
+        }
+
+        evidenceContent = {
+          $type: "org.hypercerts.defs#smallBlob",
+          blob: uploadResult.data.blob,
+        };
+      }
+
+      const evidenceRecord: HypercertEvidence = {
+        ...rest,
+        $type: HYPERCERT_COLLECTIONS.EVIDENCE,
+        createdAt,
+        content: evidenceContent,
+        subject: { uri: subject.uri, cid: subject.cid },
+      };
+      const validation = validate(evidenceRecord, HYPERCERT_COLLECTIONS.EVIDENCE, "main", false);
+      if (!validation.success) {
+        throw new ValidationError(`Invalid evidence record: ${validation.error?.message}`);
+      }
+      const result = await this.agent.com.atproto.repo.createRecord({
+        repo: this.repoDid,
+        collection: HYPERCERT_COLLECTIONS.EVIDENCE,
+        record: evidenceRecord,
       });
-
-      this.emit("evidenceAdded", { uri: result.uri, cid: result.cid });
-      return result;
+      if (!result.success) {
+        throw new NetworkError(`Failed to add evidence`);
+      }
+      this.emit("evidenceAdded", { uri: result.data.uri, cid: result.data.cid });
+      return { uri: result.data.uri, cid: result.data.cid };
     } catch (error) {
       if (error instanceof ValidationError || error instanceof NetworkError) throw error;
       throw new NetworkError(`Failed to add evidence: ${error instanceof Error ? error.message : "Unknown"}`, error);

--- a/packages/sdk-core/src/repository/HypercertOperationsImpl.ts
+++ b/packages/sdk-core/src/repository/HypercertOperationsImpl.ts
@@ -119,6 +119,28 @@ export class HypercertOperationsImpl extends EventEmitter<HypercertEvents> imple
   }
 
   /**
+   * Helper function to upload a blob to the repository, returns a blob reference
+   *
+   * @param content - Blob to upload
+   * @param fallbackContentType | if content.type is empty,we use this
+   * @returns BlobRef
+   * @throws {@link NetworkError} if upload fails
+   * @internal
+   */
+
+  private async handleBlobUpload(content: Blob, fallbackContentType: string) {
+    const arrayBuffer = await content.arrayBuffer();
+    const uint8Array = new Uint8Array(arrayBuffer);
+    const uploadResult = await this.agent.com.atproto.repo.uploadBlob(uint8Array, {
+      encoding: content.type || fallbackContentType,
+    });
+    if (!uploadResult.success) {
+      throw new NetworkError("Failed to upload blob");
+    }
+    return uploadResult.data.blob;
+  }
+
+  /**
    * Uploads an image blob and returns a blob reference.
    *
    * @param image - Image blob to upload
@@ -250,10 +272,6 @@ export class HypercertOperationsImpl extends EventEmitter<HypercertEvents> imple
       hypercertRecord.image = imageBlobRef;
     }
 
-    if (params.evidence && params.evidence.length > 0) {
-      hypercertRecord.evidence = params.evidence;
-    }
-
     const hypercertValidation = validate(hypercertRecord, HYPERCERT_COLLECTIONS.CLAIM, "main", false);
     if (!hypercertValidation.success) {
       throw new ValidationError(`Invalid hypercert record: ${hypercertValidation.error?.message}`);
@@ -351,6 +369,43 @@ export class HypercertOperationsImpl extends EventEmitter<HypercertEvents> imple
   }
 
   /**
+   * Creates evidence records with progress tracking.
+   *
+   * @param hypercertUri - URI of the hypercert
+   * @param evidenceItems - Array of evidence data (without subjectUri)
+   * @param onProgress - Optional progress callback
+   * @returns Promise resolving to array of evidence URIs
+   * @internal
+   */
+  private async createEvidenceWithProgress(
+    hypercertUri: string,
+    evidenceItems: Array<Omit<CreateHypercertEvidenceParams, "subjectUri">>,
+    onProgress?: (step: ProgressStep) => void,
+  ): Promise<string[]> {
+    this.emitProgress(onProgress, { name: "addEvidence", status: "start" });
+    try {
+      const evidenceUris = await Promise.all(
+        evidenceItems.map((evidence) =>
+          this.addEvidence({
+            subjectUri: hypercertUri,
+            ...evidence,
+          } as CreateHypercertEvidenceParams).then((result) => result.uri),
+        ),
+      );
+      this.emitProgress(onProgress, {
+        name: "addEvidence",
+        status: "success",
+        data: { count: evidenceUris.length },
+      });
+      return evidenceUris;
+    } catch (error) {
+      this.emitProgress(onProgress, { name: "addEvidence", status: "error", error: error as Error });
+      this.logger?.warn(`Failed to create evidence: ${error instanceof Error ? error.message : "Unknown"}`);
+      throw error;
+    }
+  }
+
+  /**
    * Creates a new hypercert with all related records.
    *
    * This method orchestrates the creation of a hypercert and its associated
@@ -378,6 +433,7 @@ export class HypercertOperationsImpl extends EventEmitter<HypercertEvents> imple
    * - `createHypercert`: Main hypercert record creation
    * - `attachLocation`: Location record creation
    * - `createContributions`: Contribution records creation
+   * - `addEvidence`: Evidence records creation
    *
    * @example Minimal hypercert
    * ```typescript
@@ -467,6 +523,15 @@ export class HypercertOperationsImpl extends EventEmitter<HypercertEvents> imple
             params.contributions,
             params.onProgress,
           );
+        } catch {
+          // Error already logged and progress emitted
+        }
+      }
+
+      // Step 6: Add evidence records if provided
+      if (params.evidence && params.evidence.length > 0) {
+        try {
+          result.evidenceUris = await this.createEvidenceWithProgress(hypercertUri, params.evidence, params.onProgress);
         } catch {
           // Error already logged and progress emitted
         }
@@ -857,12 +922,47 @@ export class HypercertOperationsImpl extends EventEmitter<HypercertEvents> imple
   }
 
   /**
+   * Helper function to get the content of a hypercert evidence.
+   *
+   * @param content - Blob | string
+   * @returns Promise resolving to HypercertEvidence["content"]
+   */
+  private async getHypercertEvidenceContent(content: CreateHypercertEvidenceParams["content"]) {
+    let evidenceContent: HypercertEvidence["content"];
+    if (typeof content === "string") {
+      evidenceContent = {
+        $type: "org.hypercerts.defs#uri",
+        uri: content,
+      };
+    } else {
+      const uploadedBlob = await this.handleBlobUpload(content, "application/octet-stream");
+      evidenceContent = {
+        $type: "org.hypercerts.defs#smallBlob",
+        blob: uploadedBlob,
+      };
+    }
+    return evidenceContent;
+  }
+
+  /**
    * Adds evidence to any subject via the subject ref.
    *
    * @param evidence - HypercertEvidenceInput
    * @returns Promise resolving to update result
    * @throws {@link ValidationError} if validation fails
    * @throws {@link NetworkError} if the operation fails
+   *
+   * @example
+   * ```typescript
+   * await repo.hypercerts.addEvidence({
+   *   subjectUri: "at://did:plc:u7h3dstby64di67bxaotzxcz/org.hypercerts.claim.activity/3mbvv5d7ixh2g"
+   *   content: Blob,
+   *   title: "Meeting Notes",
+   *   shortDescription: "Meetings notes from the 3rd of December 2025",
+   *   description: "The meeting with the board of directors and audience on 2025 in regards to the ecological landscape",
+   *   relationType: "supports",
+   * })
+   * ```
    */
   async addEvidence(evidence: CreateHypercertEvidenceParams): Promise<UpdateResult> {
     try {
@@ -870,30 +970,7 @@ export class HypercertOperationsImpl extends EventEmitter<HypercertEvents> imple
       const subject = await this.get(subjectUri);
       const createdAt = new Date().toISOString();
 
-      let evidenceContent: HypercertEvidence["content"];
-      if (typeof content === "string") {
-        evidenceContent = {
-          $type: "org.hypercerts.defs#uri",
-          uri: content,
-        };
-      } else {
-        // Handle Blob upload
-        const arrayBuffer = await content.arrayBuffer();
-        const uint8Array = new Uint8Array(arrayBuffer);
-        const uploadResult = await this.agent.com.atproto.repo.uploadBlob(uint8Array, {
-          encoding: content.type || "application/octet-stream",
-        });
-
-        if (!uploadResult.success) {
-          throw new NetworkError("Failed to upload evidence blob");
-        }
-
-        evidenceContent = {
-          $type: "org.hypercerts.defs#smallBlob",
-          blob: uploadResult.data.blob,
-        };
-      }
-
+      const evidenceContent = await this.getHypercertEvidenceContent(content);
       const evidenceRecord: HypercertEvidence = {
         ...rest,
         $type: HYPERCERT_COLLECTIONS.EVIDENCE,

--- a/packages/sdk-core/src/repository/interfaces.ts
+++ b/packages/sdk-core/src/repository/interfaces.ts
@@ -9,16 +9,16 @@
  */
 
 import type { EventEmitter } from "eventemitter3";
-import type { HypercertCollection, HypercertEvidence, HypercertClaim } from "../services/hypercerts/types.js";
+import type { HypercertClaim, HypercertCollection } from "../services/hypercerts/types.js";
 import type {
   CreateResult,
-  UpdateResult,
-  PaginatedList,
   ListParams,
-  RepositoryRole,
-  RepositoryAccessGrant,
   OrganizationInfo,
+  PaginatedList,
   ProgressStep,
+  RepositoryAccessGrant,
+  RepositoryRole,
+  UpdateResult,
 } from "./types.js";
 
 // ============================================================================
@@ -235,7 +235,7 @@ export interface CreateHypercertParams {
   /**
    * Optional evidence supporting the impact claim.
    */
-  evidence?: HypercertEvidence[];
+  evidence?: Array<Omit<CreateHypercertEvidenceParams, "subjectUri">>;
 
   /**
    * Optional callback for progress updates during creation.
@@ -261,6 +261,51 @@ export interface CreateOrganizationParams {
    * Optional description of the organization
    */
   description?: string;
+}
+/**
+ * Input params for creating Hypercert evidence.
+ *
+ * Based on `org.hypercerts.claim.evidence` but:
+ * - removes: $type, createdAt, subject, content
+ * - adds: subjectUri, content (string | Blob)
+ */
+export interface CreateHypercertEvidenceParams {
+  /**
+   * URI for the subject this evidence is attached to.
+   */
+  subjectUri: string;
+
+  /**
+   * Evidence content.
+   * - string: e.g. URL, IPFS URI, or inline text (depending on your conventions)
+   * - Blob: binary payload (e.g. image/pdf)
+   */
+  content: string | Blob;
+
+  /**
+   * Title to describe the nature of the evidence.
+   */
+  title: string;
+
+  /**
+   * Short description explaining what this evidence shows.
+   */
+  shortDescription?: string;
+
+  /**
+   * Longer description describing the evidence in more detail.
+   */
+  description?: string;
+
+  /**
+   * How this evidence relates to the subject.
+   */
+  relationType?: "supports" | "challenges" | "clarifies" | (string & {});
+
+  /**
+   * Any additional custom fields supported by the record.
+   */
+  [k: string]: unknown;
 }
 
 /**
@@ -707,11 +752,10 @@ export interface HypercertOperations extends EventEmitter<HypercertEvents> {
   /**
    * Adds evidence to an existing hypercert.
    *
-   * @param uri - AT-URI of the hypercert
-   * @param evidence - Array of evidence items to add
+   * @param evidence - Evidence item to add
    * @returns Promise resolving to update result
    */
-  addEvidence(uri: string, evidence: HypercertEvidence[]): Promise<UpdateResult>;
+  addEvidence(evidence: CreateHypercertEvidenceParams): Promise<UpdateResult>;
 
   /**
    * Creates a contribution record.

--- a/packages/sdk-core/src/repository/interfaces.ts
+++ b/packages/sdk-core/src/repository/interfaces.ts
@@ -277,7 +277,7 @@ export interface CreateHypercertEvidenceParams {
 
   /**
    * Evidence content.
-   * - string: e.g. URL, IPFS URI, or inline text (depending on your conventions)
+   * - string: should be a URI.
    * - Blob: binary payload (e.g. image/pdf)
    */
   content: string | Blob;
@@ -343,6 +343,11 @@ export interface CreateHypercertResult {
    * AT-URIs of contribution records, if contributions were provided.
    */
   contributionUris?: string[];
+
+  /**
+   * AT-URIs of evidence records, if evidence was provided.
+   */
+  evidenceUris?: string[];
 }
 
 // ============================================================================

--- a/packages/sdk-core/tests/repository/HypercertOperationsImpl.test.ts
+++ b/packages/sdk-core/tests/repository/HypercertOperationsImpl.test.ts
@@ -89,26 +89,54 @@ describe("HypercertOperationsImpl", () => {
       expect(hypercertCall.record.shortDescription).toBe("Short desc");
     });
 
-    it("should include evidence when provided", async () => {
+    it("should create evidence records when provided", async () => {
       const evidence = [
         {
-          $type: "org.hypercerts.claim.evidence" as const,
-          content: {
-            uri: "https://example.com/evidence",
-            $type: "org.hypercerts.defs#uri" as const,
-          },
-          title: "Evidence",
-          createdAt: new Date().toISOString(),
+          content: "https://example.com/evidence",
+          title: "Evidence Document",
+          shortDescription: "Supporting evidence",
+          relationType: "supports" as const,
         },
       ];
 
-      await hypercertOps.create({
+      // Mock getRecord for evidence creation (called by addEvidence)
+      mockAgent.com.atproto.repo.getRecord.mockResolvedValue({
+        success: true,
+        data: {
+          uri: "at://did:plc:test/org.hypercerts.claim.record/def456",
+          cid: "hypercert-cid",
+          value: {
+            title: "Test",
+            description: "Test",
+            workScope: { withinAllOf: ["Testing"] },
+            startDate: "2024-01-01",
+            endDate: "2024-12-31",
+            createdAt: "2024-01-01",
+          },
+        },
+      });
+
+      // Mock evidence record creation (third createRecord call after rights and hypercert)
+      mockAgent.com.atproto.repo.createRecord.mockResolvedValueOnce({
+        success: true,
+        data: { uri: "at://did:plc:test/org.hypercerts.claim.evidence/evidence123", cid: "evidence-cid" },
+      });
+
+      const result = await hypercertOps.create({
         ...validParams,
         evidence,
       });
 
-      const hypercertCall = mockAgent.com.atproto.repo.createRecord.mock.calls[1][0];
-      expect(hypercertCall.record.evidence).toEqual(evidence);
+      // Verify evidence records were created
+      expect(result.evidenceUris).toBeDefined();
+      expect(result.evidenceUris).toHaveLength(1);
+      expect(result.evidenceUris?.[0]).toContain("evidence");
+
+      // Verify createRecord was called for evidence (3rd call: rights, hypercert, evidence)
+      expect(mockAgent.com.atproto.repo.createRecord).toHaveBeenCalledTimes(3);
+      const evidenceCall = mockAgent.com.atproto.repo.createRecord.mock.calls[2][0];
+      expect(evidenceCall.collection).toBe("org.hypercerts.claim.evidence");
+      expect(evidenceCall.record.title).toBe("Evidence Document");
     });
 
     it("should attach location when provided", async () => {

--- a/packages/sdk-core/tests/repository/HypercertOperationsImpl.test.ts
+++ b/packages/sdk-core/tests/repository/HypercertOperationsImpl.test.ts
@@ -540,6 +540,88 @@ describe("HypercertOperationsImpl", () => {
     });
   });
 
+  describe("addEvidence", () => {
+    beforeEach(() => {
+      mockAgent.com.atproto.repo.getRecord.mockResolvedValue({
+        success: true,
+        data: {
+          uri: "at://did:plc:test/org.hypercerts.claim.record/abc",
+          cid: "hypercert-cid",
+          value: {
+            title: "Test",
+            description: "Test",
+            workScope: {
+              withinAllOf: ["Climate"],
+              withinAnyOf: [],
+              withinNoneOf: [],
+            },
+            startDate: "2024-01-01",
+            endDate: "2024-12-31",
+            createdAt: "2024-01-01",
+          },
+        },
+      });
+
+      mockAgent.com.atproto.repo.createRecord.mockResolvedValue({
+        success: true,
+        data: { uri: "at://did:plc:test/org.hypercerts.claim.evidence/xyz", cid: "evidence-cid" },
+      });
+    });
+
+    it("should add evidence to a hypercert with a URI string", async () => {
+      const result = await hypercertOps.addEvidence({
+        subjectUri: "at://did:plc:test/org.hypercerts.claim.record/abc",
+        title: "Impact Report",
+        content: "https://example.com/report.pdf",
+      });
+
+      expect(result.uri).toContain("evidence");
+      expect(mockAgent.com.atproto.repo.createRecord).toHaveBeenCalled();
+      const call = mockAgent.com.atproto.repo.createRecord.mock.calls[0][0];
+      expect(call.record.content).toEqual({
+        $type: "org.hypercerts.defs#uri",
+        uri: "https://example.com/report.pdf",
+      });
+    });
+
+    it("should add evidence to a hypercert with a Blob upload", async () => {
+      const blob = new Blob(["evidence data"], { type: "application/pdf" });
+      mockAgent.com.atproto.repo.uploadBlob.mockResolvedValue({
+        success: true,
+        data: {
+          blob: { ref: { $link: "blob-cid" }, mimeType: "application/pdf", size: 100 },
+        },
+      });
+
+      const result = await hypercertOps.addEvidence({
+        subjectUri: "at://did:plc:test/org.hypercerts.claim.record/abc",
+        title: "Impact Report",
+        content: blob,
+      });
+
+      expect(result.uri).toContain("evidence");
+      expect(mockAgent.com.atproto.repo.uploadBlob).toHaveBeenCalled();
+      const call = mockAgent.com.atproto.repo.createRecord.mock.calls[0][0];
+      expect(call.record.content).toEqual({
+        $type: "org.hypercerts.defs#smallBlob",
+        blob: { ref: { $link: "blob-cid" }, mimeType: "application/pdf", size: 100 },
+      });
+    });
+
+    it("should emit evidenceAdded event", async () => {
+      const handler = vi.fn();
+      hypercertOps.on("evidenceAdded", handler);
+
+      await hypercertOps.addEvidence({
+        subjectUri: "at://did:plc:test/org.hypercerts.claim.record/abc",
+        title: "Impact Report",
+        content: "https://example.com/report.pdf",
+      });
+
+      expect(handler).toHaveBeenCalledWith({ uri: expect.any(String), cid: "evidence-cid" });
+    });
+  });
+
   describe("addMeasurement", () => {
     beforeEach(() => {
       mockAgent.com.atproto.repo.getRecord.mockResolvedValue({


### PR DESCRIPTION
Currently evidence gets saved inside of the hypercert. However according to our lexicons we have to store it as a record which links to the hypercert through the subject uri.

Also the sdk currently expects the whole body from whoever is using it, with `$type` and also creating the subject uri. Which isnt the most developer friendly. So mimicking hypercert.create, sdk `addEvidence` now handles the record creation, blob  upload and linking with the hypercert URI.

Fixes #76 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * addEvidence now takes a single evidence input object and evidence is no longer embedded in hypercerts — access via result.evidenceUris.

* **New Features**
  * Evidence created as separate records (URI or uploaded blob).
  * create() adds evidence in parallel and exposes evidenceUris.
  * Added progress-tracked evidence creation (createEvidenceWithProgress).

* **Tests**
  * Added tests for URI/blob evidence creation and evidence-added events.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->