### PR TITLE
Allow loopback urls

### DIFF
--- a/.changeset/loopback-url-support.md
+++ b/.changeset/loopback-url-support.md
@@ -5,7 +5,8 @@
 
 feat: add HTTP loopback URL support for local development
 
-Enable local development and testing with HTTP loopback URLs (`http://localhost`, `http://127.0.0.1`, `http://[::1]`) while maintaining security for production deployments.
+Enable local development and testing with HTTP loopback URLs (`http://localhost`, `http://127.0.0.1`, `http://[::1]`)
+while maintaining security for production deployments.
 
 **Configuration Updates**
 
@@ -13,7 +14,8 @@ Enable local development and testing with HTTP loopback URLs (`http://localhost`
 - Update `OAuthConfigSchema` to allow loopback URLs for `clientId`, `redirectUri`, `jwksUri`
 - Add optional `developmentMode` boolean flag to suppress warnings
 - Update `ServerConfigSchema` to allow loopback URLs for PDS/SDS servers
-- Export `isLoopbackUrl()` helper function and TypeScript types (`LoopbackUrl`, `HttpsUrl`, `DevelopmentOrProductionUrl`)
+- Export `isLoopbackUrl()` helper function and TypeScript types (`LoopbackUrl`, `HttpsUrl`,
+  `DevelopmentOrProductionUrl`)
 
 **Development Mode Features**
 
@@ -41,4 +43,5 @@ Enable local development and testing with HTTP loopback URLs (`http://localhost`
 
 **Migration**: No migration needed for existing configurations. Existing HTTPS URLs continue to work without changes.
 
-This feature enables developers to test the SDK locally without requiring HTTPS certificates, while the underlying `@atproto/oauth-client-node` library handles loopback OAuth flows per the AT Protocol specification.
+This feature enables developers to test the SDK locally without requiring HTTPS certificates, while the underlying
+`@atproto/oauth-client-node` library handles loopback OAuth flows per the AT Protocol specification.

--- a/.changeset/loopback-url-support.md
+++ b/.changeset/loopback-url-support.md
@@ -1,0 +1,44 @@
+---
+"@hypercerts-org/sdk-core": minor
+"@hypercerts-org/sdk-react": patch
+---
+
+feat: add HTTP loopback URL support for local development
+
+Enable local development and testing with HTTP loopback URLs (`http://localhost`, `http://127.0.0.1`, `http://[::1]`) while maintaining security for production deployments.
+
+**Configuration Updates**
+
+- Custom URL validator accepting HTTPS URLs or HTTP loopback addresses
+- Update `OAuthConfigSchema` to allow loopback URLs for `clientId`, `redirectUri`, `jwksUri`
+- Add optional `developmentMode` boolean flag to suppress warnings
+- Update `ServerConfigSchema` to allow loopback URLs for PDS/SDS servers
+- Export `isLoopbackUrl()` helper function and TypeScript types (`LoopbackUrl`, `HttpsUrl`, `DevelopmentOrProductionUrl`)
+
+**Development Mode Features**
+
+- Automatic loopback detection with informative logging
+- Warning when using loopback URLs without explicit `developmentMode` flag
+- Info logs indicating development mode is active
+- Clear guidance about authorization server requirements
+
+**Testing**
+
+- 28 new unit tests for loopback URL validation
+- Tests cover localhost, 127.0.0.1, and [::1] (IPv6) loopback addresses
+- Tests verify rejection of non-loopback HTTP URLs
+- Tests ensure HTTPS URLs always accepted
+
+**Documentation**
+
+- Comprehensive local development guide in Core SDK README
+- NextJS App Router example with loopback configuration
+- API route setup examples (OAuth callback, JWKS endpoint)
+- Important notes about authorization server support and production safety
+- Local development example added to React SDK factory JSDoc
+
+**Breaking Changes**: None - fully backward compatible
+
+**Migration**: No migration needed for existing configurations. Existing HTTPS URLs continue to work without changes.
+
+This feature enables developers to test the SDK locally without requiring HTTPS certificates, while the underlying `@atproto/oauth-client-node` library handles loopback OAuth flows per the AT Protocol specification.

--- a/CERTS_SDK.md
+++ b/CERTS_SDK.md
@@ -124,9 +124,7 @@ import { queryClient, ATProtoProvider } from "@/lib/atproto";
 export function Providers({ children }: { children: React.ReactNode }) {
   return (
     <QueryClientProvider client={queryClient}>
-      <ATProtoProvider>
-        {children}
-      </ATProtoProvider>
+      <ATProtoProvider>{children}</ATProtoProvider>
       <ReactQueryDevtools initialIsOpen={false} />
     </QueryClientProvider>
   );
@@ -139,11 +137,7 @@ Wrap your app in the root layout:
 // app/layout.tsx
 import { Providers } from "./providers";
 
-export default function RootLayout({
-  children,
-}: {
-  children: React.ReactNode;
-}) {
+export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en">
       <body>
@@ -201,9 +195,7 @@ export function AuthButton() {
 
   return (
     <div>
-      <button onClick={() => login("bsky.social")}>
-        Sign in with Bluesky
-      </button>
+      <button onClick={() => login("bsky.social")}>Sign in with Bluesky</button>
       {error && <p className="error">{error.message}</p>}
     </div>
   );
@@ -249,13 +241,7 @@ export function Profile() {
 import { useHypercerts } from "@/lib/atproto";
 
 export function HypercertList() {
-  const {
-    hypercerts,
-    isLoading,
-    create,
-    isCreating,
-    error,
-  } = useHypercerts();
+  const { hypercerts, isLoading, create, isCreating, error } = useHypercerts();
 
   const handleCreate = async () => {
     const result = await create({
@@ -315,17 +301,11 @@ export function HypercertDetail({ uri }: { uri: string }) {
       <h1>{hypercert.value.title}</h1>
       <p>{hypercert.value.description}</p>
 
-      <button
-        onClick={() => update({ title: "Updated Title" })}
-        disabled={isUpdating}
-      >
+      <button onClick={() => update({ title: "Updated Title" })} disabled={isUpdating}>
         Update
       </button>
 
-      <button
-        onClick={() => remove()}
-        disabled={isDeleting}
-      >
+      <button onClick={() => remove()} disabled={isDeleting}>
         Delete
       </button>
     </div>
@@ -634,11 +614,7 @@ export function Providers({ children }: { children: React.ReactNode }) {
 // app/layout.tsx
 import { Providers } from "./providers";
 
-export default function RootLayout({
-  children,
-}: {
-  children: React.ReactNode;
-}) {
+export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en">
       <body>
@@ -699,9 +675,7 @@ export default function Home() {
           </button>
         </div>
       ) : (
-        <button onClick={() => login("bsky.social")}>
-          Sign in with Bluesky
-        </button>
+        <button onClick={() => login("bsky.social")}>Sign in with Bluesky</button>
       )}
     </main>
   );
@@ -722,7 +696,9 @@ const queryClient = new QueryClient();
 
 const atproto = createATProtoReact({
   queryClient, // Same instance used by wagmi
-  config: { /* ... */ },
+  config: {
+    /* ... */
+  },
 });
 
 function App() {
@@ -749,7 +725,9 @@ const queryClient = new QueryClient();
 
 const atproto = createATProtoReact({
   queryClient,
-  config: { /* ... */ },
+  config: {
+    /* ... */
+  },
 });
 
 function App() {
@@ -815,7 +793,7 @@ describe("MyComponent", () => {
     render(
       <TestProvider initialSession={mockSession}>
         <MyComponent />
-      </TestProvider>
+      </TestProvider>,
     );
 
     expect(screen.getByText("Welcome")).toBeInTheDocument();

--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ const atproto = createATProtoReact({ config, queryClient });
       <App />
     </atproto.Provider>
   </WagmiProvider>
-</QueryClientProvider>
+</QueryClientProvider>;
 ```
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -339,6 +339,8 @@ npm install @hypercerts-org/sdk-react@beta
 
 ## Documentation
 
+- **[Core SDK Documentation](./packages/sdk-core/README.md)** - Complete SDK reference with local development guide
+- **[React SDK Documentation](./packages/sdk-react/README.md)** - React hooks and components
 - [Implementation Plan](./IMPLEMENTATION_PLAN.MD) - Detailed architecture and implementation phases
 - [Core & Auth Spec](./specs/01-core-and-auth.md) - OAuth and session management
 - [Repository & Lexicons Spec](./specs/02-repository-and-lexicons.md) - Repository operations

--- a/packages/sdk-core/README.md
+++ b/packages/sdk-core/README.md
@@ -65,18 +65,18 @@ const sdk = createATProtoSDK({
   oauth: {
     // Use localhost for client_id (loopback client)
     clientId: "http://localhost/",
-    
+
     // Use 127.0.0.1 with your app's port for redirect
     redirectUri: "http://127.0.0.1:3000/api/auth/callback",
-    
+
     scope: "atproto",
-    
+
     // Serve JWKS from your app
     jwksUri: "http://127.0.0.1:3000/.well-known/jwks.json",
-    
+
     // Load from environment variable
     jwkPrivate: process.env.ATPROTO_JWK_PRIVATE!,
-    
+
     // Optional: suppress warnings
     developmentMode: true,
   },
@@ -98,10 +98,10 @@ import sdk from "@/lib/atproto";
 
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
-  
+
   try {
     const session = await sdk.callback(searchParams);
-    
+
     // Store session (use secure httpOnly cookie in production)
     return Response.json({ success: true, did: session.sub });
   } catch (error) {
@@ -116,10 +116,10 @@ export async function GET(request: Request) {
 // app/.well-known/jwks.json/route.ts
 export async function GET() {
   const jwk = JSON.parse(process.env.ATPROTO_JWK_PRIVATE!);
-  
+
   // Return public keys only (remove private key 'd' parameter)
   const publicKeys = jwk.keys.map(({ d, ...publicKey }) => publicKey);
-  
+
   return Response.json({ keys: publicKeys });
 }
 ```
@@ -133,13 +133,16 @@ ATPROTO_JWK_PRIVATE='{"keys":[{"kty":"EC","crv":"P-256",...}]}'
 
 ### Important Notes
 
-> **Authorization Server Support**: The AT Protocol OAuth spec makes loopback support **optional**. Most AT Protocol servers support loopback clients for development, but verify your target authorization server supports this feature.
+> **Authorization Server Support**: The AT Protocol OAuth spec makes loopback support **optional**. Most AT Protocol
+> servers support loopback clients for development, but verify your target authorization server supports this feature.
 
-> **Port Matching**: Redirect URIs can use any port - the authorization server ignores port numbers when validating loopback redirects (only the path must match).
+> **Port Matching**: Redirect URIs can use any port - the authorization server ignores port numbers when validating
+> loopback redirects (only the path must match).
 
 > **Production Use**: ⚠️ Never use HTTP loopback URLs in production. Always use HTTPS with proper TLS certificates.
 
-> **IP vs Hostname**: Use `http://localhost/` for `clientId` and `http://127.0.0.1:<port>` for `redirectUri` and `jwksUri` (this is the recommended pattern per AT Protocol spec).
+> **IP vs Hostname**: Use `http://localhost/` for `clientId` and `http://127.0.0.1:<port>` for `redirectUri` and
+> `jwksUri` (this is the recommended pattern per AT Protocol spec).
 
 ## Core Concepts
 

--- a/packages/sdk-core/README.md
+++ b/packages/sdk-core/README.md
@@ -51,6 +51,96 @@ const claim = await repo.hypercerts.create({
 });
 ```
 
+## Local Development
+
+For local development and testing, you can use HTTP loopback URLs with `localhost` or `127.0.0.1`:
+
+### NextJS App Router Example
+
+```typescript
+// lib/atproto.ts
+import { createATProtoSDK } from "@hypercerts-org/sdk-core";
+
+const sdk = createATProtoSDK({
+  oauth: {
+    // Use localhost for client_id (loopback client)
+    clientId: "http://localhost/",
+    
+    // Use 127.0.0.1 with your app's port for redirect
+    redirectUri: "http://127.0.0.1:3000/api/auth/callback",
+    
+    scope: "atproto",
+    
+    // Serve JWKS from your app
+    jwksUri: "http://127.0.0.1:3000/.well-known/jwks.json",
+    
+    // Load from environment variable
+    jwkPrivate: process.env.ATPROTO_JWK_PRIVATE!,
+    
+    // Optional: suppress warnings
+    developmentMode: true,
+  },
+  servers: {
+    // Point to local PDS for testing
+    pds: "http://localhost:2583",
+  },
+  logger: console, // Enable debug logging
+});
+
+export default sdk;
+```
+
+### API Route Setup
+
+```typescript
+// app/api/auth/callback/route.ts
+import sdk from "@/lib/atproto";
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  
+  try {
+    const session = await sdk.callback(searchParams);
+    
+    // Store session (use secure httpOnly cookie in production)
+    return Response.json({ success: true, did: session.sub });
+  } catch (error) {
+    return Response.json({ error: "Authentication failed" }, { status: 401 });
+  }
+}
+```
+
+### Serve JWKS Endpoint
+
+```typescript
+// app/.well-known/jwks.json/route.ts
+export async function GET() {
+  const jwk = JSON.parse(process.env.ATPROTO_JWK_PRIVATE!);
+  
+  // Return public keys only (remove private key 'd' parameter)
+  const publicKeys = jwk.keys.map(({ d, ...publicKey }) => publicKey);
+  
+  return Response.json({ keys: publicKeys });
+}
+```
+
+### Environment Variables
+
+```bash
+# .env.local
+ATPROTO_JWK_PRIVATE='{"keys":[{"kty":"EC","crv":"P-256",...}]}'
+```
+
+### Important Notes
+
+> **Authorization Server Support**: The AT Protocol OAuth spec makes loopback support **optional**. Most AT Protocol servers support loopback clients for development, but verify your target authorization server supports this feature.
+
+> **Port Matching**: Redirect URIs can use any port - the authorization server ignores port numbers when validating loopback redirects (only the path must match).
+
+> **Production Use**: ⚠️ Never use HTTP loopback URLs in production. Always use HTTPS with proper TLS certificates.
+
+> **IP vs Hostname**: Use `http://localhost/` for `clientId` and `http://127.0.0.1:<port>` for `redirectUri` and `jwksUri` (this is the recommended pattern per AT Protocol spec).
+
 ## Core Concepts
 
 ### 1. PDS vs SDS: Understanding Server Types

--- a/packages/sdk-core/src/auth/OAuthClient.ts
+++ b/packages/sdk-core/src/auth/OAuthClient.ts
@@ -1,6 +1,7 @@
 import { NodeOAuthClient, JoseKey, type NodeSavedSession } from "@atproto/oauth-client-node";
 import type { SessionStore, StateStore, LoggerInterface } from "../core/interfaces.js";
 import type { ATProtoSDKConfig } from "../core/config.js";
+import { isLoopbackUrl } from "../lib/url-utils.js";
 import { AuthenticationError, NetworkError } from "../core/errors.js";
 import { InMemorySessionStore } from "../storage/InMemorySessionStore.js";
 import { InMemoryStateStore } from "../storage/InMemoryStateStore.js";
@@ -163,6 +164,26 @@ export class OAuthClient {
   }
 
   /**
+   * Detects if a URL is a loopback address (localhost or 127.0.0.1 or [::1]).
+   *
+   * @param urlString - The URL to check
+   * @returns True if the URL is an HTTP loopback address
+   * @internal
+   */
+  private isLoopbackUrl(urlString: string): boolean {
+    try {
+      const url = new URL(urlString);
+      if (url.protocol !== "http:") {
+        return false;
+      }
+      const hostname = url.hostname.toLowerCase();
+      return hostname === "localhost" || hostname === "127.0.0.1" || hostname === "[::1]";
+    } catch {
+      return false;
+    }
+  }
+
+  /**
    * Builds OAuth client metadata from configuration.
    *
    * The metadata describes your application to the authorization server
@@ -180,6 +201,27 @@ export class OAuthClient {
    */
   private buildClientMetadata() {
     const clientIdUrl = new URL(this.config.oauth.clientId);
+
+    // Detect and warn about loopback configuration
+    const isDevelopment = isLoopbackUrl(this.config.oauth.clientId) || isLoopbackUrl(this.config.oauth.redirectUri);
+
+    if (isDevelopment && !this.config.oauth.developmentMode) {
+      this.logger?.warn("Using HTTP loopback URLs without explicit developmentMode flag", {
+        clientId: this.config.oauth.clientId,
+        redirectUri: this.config.oauth.redirectUri,
+        note: "This is suitable for local development only. For production, use HTTPS URLs.",
+        recommendation: "Set oauth.developmentMode: true to suppress this warning.",
+      });
+    }
+
+    if (isDevelopment) {
+      this.logger?.info("Running in development mode with loopback URLs", {
+        clientId: this.config.oauth.clientId,
+        redirectUri: this.config.oauth.redirectUri,
+        note: "Authorization server must support loopback clients (optional per AT Protocol spec)",
+      });
+    }
+
     const metadata = {
       client_id: this.config.oauth.clientId,
       client_name: "ATProto SDK Client",

--- a/packages/sdk-core/src/core/config.ts
+++ b/packages/sdk-core/src/core/config.ts
@@ -2,26 +2,88 @@ import { z } from "zod";
 import type { SessionStore, StateStore, CacheInterface, LoggerInterface } from "./interfaces.js";
 
 /**
+ * Type for HTTP loopback URLs (localhost, 127.0.0.1, [::1])
+ */
+export type LoopbackUrl = `http://localhost${string}` | `http://127.0.0.1${string}` | `http://[::1]${string}`;
+
+/**
+ * Type for HTTPS URLs (production)
+ */
+export type HttpsUrl = `https://${string}`;
+
+/**
+ * Type for URLs that can be used in development or production
+ */
+export type DevelopmentOrProductionUrl = HttpsUrl | LoopbackUrl;
+
+/**
+ * Custom URL validator that allows HTTP loopback addresses for development.
+ *
+ * Accepts:
+ * - Any HTTPS URL (production)
+ * - http://localhost (with optional port and path)
+ * - http://127.0.0.1 (with optional port and path)
+ * - http://[::1] (with optional port and path) - IPv6 loopback
+ *
+ * Rejects:
+ * - Other HTTP URLs (e.g., http://example.com)
+ * - Invalid URLs
+ *
+ * @internal
+ */
+const urlOrLoopback = z.string().refine(
+  (value) => {
+    try {
+      const url = new URL(value);
+
+      // Always allow HTTPS
+      if (url.protocol === "https:") {
+        return true;
+      }
+
+      // For HTTP, only allow loopback addresses
+      if (url.protocol === "http:") {
+        const hostname = url.hostname.toLowerCase();
+        return hostname === "localhost" || hostname === "127.0.0.1" || hostname === "[::1]";
+      }
+
+      return false;
+    } catch {
+      return false;
+    }
+  },
+  {
+    message: "Must be a valid HTTPS URL or HTTP loopback URL (localhost, 127.0.0.1, [::1])",
+  },
+);
+
+/**
  * Zod schema for OAuth configuration validation.
  *
  * @remarks
- * All URLs must be valid and use HTTPS in production. The `jwkPrivate` field
- * should contain the private key in JWK (JSON Web Key) format as a string.
+ * All URLs must be valid and use HTTPS in production. For local development,
+ * HTTP loopback URLs (localhost, 127.0.0.1, [::1]) are allowed.
+ * The `jwkPrivate` field should contain the private key in JWK (JSON Web Key) format as a string.
  */
 export const OAuthConfigSchema = z.object({
   /**
    * URL to the OAuth client metadata JSON document.
    * This document describes your application to the authorization server.
    *
+   * For local development, you can use `http://localhost/` as a loopback client.
+   *
    * @see https://atproto.com/specs/oauth#client-metadata
    */
-  clientId: z.string().url(),
+  clientId: urlOrLoopback,
 
   /**
    * URL where users are redirected after authentication.
    * Must match one of the redirect URIs in your client metadata.
+   *
+   * For local development, you can use HTTP loopback URLs like
+   * `http://127.0.0.1:3000/callback` or `http://localhost:3000/callback`.
    */
-  redirectUri: z.string().url(),
+  redirectUri: urlOrLoopback,
 
   /**
    * OAuth scopes to request, space-separated.
@@ -57,8 +119,11 @@ export const OAuthConfigSchema = z.object({
   /**
    * URL to your public JWKS (JSON Web Key Set) endpoint.
    * Used by the authorization server to verify your client's signatures.
+   *
+   * For local development, you can serve JWKS from a loopback URL like
+   * `http://127.0.0.1:3000/.well-known/jwks.json`.
    */
-  jwksUri: z.string().url(),
+  jwksUri: urlOrLoopback,
 
   /**
    * Private JWK (JSON Web Key) as a JSON string.
@@ -69,6 +134,26 @@ export const OAuthConfigSchema = z.object({
    * Typically loaded from environment variables or a secrets manager.
    */
   jwkPrivate: z.string(),
+
+  /**
+   * Enable development mode features (optional).
+   *
+   * When true, suppresses warnings about using HTTP loopback URLs.
+   * Should be set to true for local development to reduce console noise.
+   *
+   * @default false
+   *
+   * @example
+   * ```typescript
+   * oauth: {
+   *   clientId: "http://localhost/",
+   *   redirectUri: "http://127.0.0.1:3000/callback",
+   *   // ... other config
+   *   developmentMode: true, // Suppress loopback warnings
+   * }
+   * ```
+   */
+  developmentMode: z.boolean().optional(),
 });
 
 /**
@@ -76,23 +161,40 @@ export const OAuthConfigSchema = z.object({
  *
  * @remarks
  * At least one server (PDS or SDS) should be configured for the SDK to be useful.
+ * For local development, HTTP loopback URLs are allowed.
  */
 export const ServerConfigSchema = z.object({
   /**
    * Personal Data Server URL - the user's own AT Protocol server.
    * This is the primary server for user data operations.
    *
-   * @example "https://bsky.social"
+   * @example Production
+   * ```typescript
+   * pds: "https://bsky.social"
+   * ```
+   *
+   * @example Local development
+   * ```typescript
+   * pds: "http://localhost:2583"
+   * ```
    */
-  pds: z.string().url().optional(),
+  pds: urlOrLoopback.optional(),
 
   /**
    * Shared Data Server URL - for collaborative data storage.
    * Required for collaborator and organization operations.
    *
-   * @example "https://sds.hypercerts.org"
+   * @example Production
+   * ```typescript
+   * sds: "https://sds.hypercerts.org"
+   * ```
+   *
+   * @example Local development
+   * ```typescript
+   * sds: "http://127.0.0.1:2584"
+   * ```
    */
-  sds: z.string().url().optional(),
+  sds: urlOrLoopback.optional(),
 });
 
 /**

--- a/packages/sdk-core/src/lib/url-utils.ts
+++ b/packages/sdk-core/src/lib/url-utils.ts
@@ -1,0 +1,30 @@
+/**
+ * Type guard to check if a URL is a loopback address.
+ *
+ * Loopback addresses are used for local development and testing.
+ * They include localhost, 127.0.0.1, and [::1] (IPv6 loopback).
+ *
+ * @param url - The URL to check
+ * @returns True if the URL is a loopback address
+ *
+ * @example
+ * ```typescript
+ * isLoopbackUrl('http://localhost:3000'); // true
+ * isLoopbackUrl('http://127.0.0.1:8080'); // true
+ * isLoopbackUrl('http://[::1]:3000'); // true
+ * isLoopbackUrl('http://example.com'); // false
+ * isLoopbackUrl('https://localhost:3000'); // false (must be http)
+ * ```
+ */
+export function isLoopbackUrl(url: string): boolean {
+  try {
+    const parsed = new URL(url);
+    if (parsed.protocol !== "http:") {
+      return false;
+    }
+    const hostname = parsed.hostname.toLowerCase();
+    return hostname === "localhost" || hostname === "127.0.0.1" || hostname === "[::1]";
+  } catch {
+    return false;
+  }
+}

--- a/packages/sdk-core/tests/core/config.test.ts
+++ b/packages/sdk-core/tests/core/config.test.ts
@@ -1,0 +1,410 @@
+import { describe, it, expect } from "vitest";
+import { ATProtoSDKConfigSchema } from "../../src/core/config.js";
+import { isLoopbackUrl } from "../../src/lib/url-utils.js";
+
+describe("URL Validation with Loopback Support", () => {
+  const validJWK = JSON.stringify({
+    keys: [
+      {
+        kty: "EC",
+        crv: "P-256",
+        kid: "test-key-1",
+        use: "sig",
+        x: "test",
+        y: "test",
+        d: "test",
+      },
+    ],
+  });
+
+  describe("isLoopbackUrl helper", () => {
+    it("returns true for http://localhost", () => {
+      expect(isLoopbackUrl("http://localhost/")).toBe(true);
+      expect(isLoopbackUrl("http://localhost:3000")).toBe(true);
+      expect(isLoopbackUrl("http://localhost:3000/path")).toBe(true);
+    });
+
+    it("returns true for http://127.0.0.1", () => {
+      expect(isLoopbackUrl("http://127.0.0.1/")).toBe(true);
+      expect(isLoopbackUrl("http://127.0.0.1:3000")).toBe(true);
+      expect(isLoopbackUrl("http://127.0.0.1:8080/path")).toBe(true);
+    });
+
+    it("returns true for http://[::1] IPv6 loopback", () => {
+      expect(isLoopbackUrl("http://[::1]/")).toBe(true);
+      expect(isLoopbackUrl("http://[::1]:3000")).toBe(true);
+      expect(isLoopbackUrl("http://[::1]:8080/path")).toBe(true);
+    });
+
+    it("returns false for https://localhost (must be http)", () => {
+      expect(isLoopbackUrl("https://localhost/")).toBe(false);
+      expect(isLoopbackUrl("https://localhost:3000")).toBe(false);
+      expect(isLoopbackUrl("https://127.0.0.1:3000")).toBe(false);
+    });
+
+    it("returns false for non-loopback http URLs", () => {
+      expect(isLoopbackUrl("http://example.com")).toBe(false);
+      expect(isLoopbackUrl("http://192.168.1.1")).toBe(false);
+      expect(isLoopbackUrl("http://10.0.0.1")).toBe(false);
+    });
+
+    it("returns false for invalid URLs", () => {
+      expect(isLoopbackUrl("not-a-url")).toBe(false);
+      expect(isLoopbackUrl("")).toBe(false);
+    });
+  });
+
+  describe("clientId validation", () => {
+    it("accepts http://localhost/", () => {
+      const config = {
+        oauth: {
+          clientId: "http://localhost/",
+          redirectUri: "http://localhost:3000/callback",
+          scope: "atproto",
+          jwksUri: "https://example.com/jwks.json",
+          jwkPrivate: validJWK,
+        },
+      };
+
+      expect(() => ATProtoSDKConfigSchema.parse(config)).not.toThrow();
+    });
+
+    it("accepts http://localhost with port", () => {
+      const config = {
+        oauth: {
+          clientId: "http://localhost:8080/client-metadata.json",
+          redirectUri: "http://localhost:3000/callback",
+          scope: "atproto",
+          jwksUri: "https://example.com/jwks.json",
+          jwkPrivate: validJWK,
+        },
+      };
+
+      expect(() => ATProtoSDKConfigSchema.parse(config)).not.toThrow();
+    });
+
+    it("accepts http://127.0.0.1 with port", () => {
+      const config = {
+        oauth: {
+          clientId: "http://127.0.0.1:3000/",
+          redirectUri: "http://127.0.0.1:3000/callback",
+          scope: "atproto",
+          jwksUri: "http://127.0.0.1:3000/jwks.json",
+          jwkPrivate: validJWK,
+        },
+      };
+
+      expect(() => ATProtoSDKConfigSchema.parse(config)).not.toThrow();
+    });
+
+    it("accepts http://[::1] IPv6 loopback", () => {
+      const config = {
+        oauth: {
+          clientId: "http://[::1]:3000/",
+          redirectUri: "http://[::1]:3000/callback",
+          scope: "atproto",
+          jwksUri: "http://[::1]:3000/jwks.json",
+          jwkPrivate: validJWK,
+        },
+      };
+
+      expect(() => ATProtoSDKConfigSchema.parse(config)).not.toThrow();
+    });
+
+    it("rejects http:// URLs for non-loopback hosts", () => {
+      const config = {
+        oauth: {
+          clientId: "http://example.com/client-metadata.json",
+          redirectUri: "https://example.com/callback",
+          scope: "atproto",
+          jwksUri: "https://example.com/jwks.json",
+          jwkPrivate: validJWK,
+        },
+      };
+
+      const result = ATProtoSDKConfigSchema.safeParse(config);
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.issues[0].message).toContain("loopback");
+      }
+    });
+
+    it("always accepts https:// URLs", () => {
+      const config = {
+        oauth: {
+          clientId: "https://example.com/client-metadata.json",
+          redirectUri: "https://example.com/callback",
+          scope: "atproto",
+          jwksUri: "https://example.com/jwks.json",
+          jwkPrivate: validJWK,
+        },
+      };
+
+      expect(() => ATProtoSDKConfigSchema.parse(config)).not.toThrow();
+    });
+  });
+
+  describe("redirectUri validation", () => {
+    it("accepts localhost redirect", () => {
+      const config = {
+        oauth: {
+          clientId: "http://localhost/",
+          redirectUri: "http://localhost:3000/api/auth/callback",
+          scope: "atproto",
+          jwksUri: "http://localhost:3000/jwks.json",
+          jwkPrivate: validJWK,
+        },
+      };
+
+      expect(() => ATProtoSDKConfigSchema.parse(config)).not.toThrow();
+    });
+
+    it("accepts 127.0.0.1 redirect", () => {
+      const config = {
+        oauth: {
+          clientId: "http://localhost/",
+          redirectUri: "http://127.0.0.1:3000/callback",
+          scope: "atproto",
+          jwksUri: "http://localhost:3000/jwks.json",
+          jwkPrivate: validJWK,
+        },
+      };
+
+      expect(() => ATProtoSDKConfigSchema.parse(config)).not.toThrow();
+    });
+
+    it("accepts IPv6 loopback redirect", () => {
+      const config = {
+        oauth: {
+          clientId: "http://localhost/",
+          redirectUri: "http://[::1]:3000/api/callback",
+          scope: "atproto",
+          jwksUri: "http://localhost:3000/jwks.json",
+          jwkPrivate: validJWK,
+        },
+      };
+
+      expect(() => ATProtoSDKConfigSchema.parse(config)).not.toThrow();
+    });
+
+    it("rejects non-loopback http redirect", () => {
+      const config = {
+        oauth: {
+          clientId: "https://example.com/",
+          redirectUri: "http://example.com:3000/callback",
+          scope: "atproto",
+          jwksUri: "https://example.com/jwks.json",
+          jwkPrivate: validJWK,
+        },
+      };
+
+      const result = ATProtoSDKConfigSchema.safeParse(config);
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.issues.some((issue) => issue.message.includes("loopback"))).toBe(true);
+      }
+    });
+  });
+
+  describe("jwksUri validation", () => {
+    it("accepts loopback jwksUri", () => {
+      const config = {
+        oauth: {
+          clientId: "http://localhost/",
+          redirectUri: "http://127.0.0.1:3000/callback",
+          scope: "atproto",
+          jwksUri: "http://127.0.0.1:3000/.well-known/jwks.json",
+          jwkPrivate: validJWK,
+        },
+      };
+
+      expect(() => ATProtoSDKConfigSchema.parse(config)).not.toThrow();
+    });
+
+    it("accepts https jwksUri with loopback clientId", () => {
+      const config = {
+        oauth: {
+          clientId: "http://localhost/",
+          redirectUri: "http://127.0.0.1:3000/callback",
+          scope: "atproto",
+          jwksUri: "https://example.com/jwks.json",
+          jwkPrivate: validJWK,
+        },
+      };
+
+      expect(() => ATProtoSDKConfigSchema.parse(config)).not.toThrow();
+    });
+  });
+
+  describe("server URLs validation", () => {
+    it("accepts loopback PDS URL", () => {
+      const config = {
+        oauth: {
+          clientId: "http://localhost/",
+          redirectUri: "http://localhost:3000/callback",
+          scope: "atproto",
+          jwksUri: "http://localhost:3000/jwks.json",
+          jwkPrivate: validJWK,
+        },
+        servers: {
+          pds: "http://localhost:2583",
+        },
+      };
+
+      expect(() => ATProtoSDKConfigSchema.parse(config)).not.toThrow();
+    });
+
+    it("accepts loopback SDS URL", () => {
+      const config = {
+        oauth: {
+          clientId: "http://localhost/",
+          redirectUri: "http://localhost:3000/callback",
+          scope: "atproto",
+          jwksUri: "http://localhost:3000/jwks.json",
+          jwkPrivate: validJWK,
+        },
+        servers: {
+          sds: "http://127.0.0.1:2584",
+        },
+      };
+
+      expect(() => ATProtoSDKConfigSchema.parse(config)).not.toThrow();
+    });
+
+    it("accepts both loopback PDS and SDS", () => {
+      const config = {
+        oauth: {
+          clientId: "http://localhost/",
+          redirectUri: "http://localhost:3000/callback",
+          scope: "atproto",
+          jwksUri: "http://localhost:3000/jwks.json",
+          jwkPrivate: validJWK,
+        },
+        servers: {
+          pds: "http://localhost:2583",
+          sds: "http://127.0.0.1:2584",
+        },
+      };
+
+      expect(() => ATProtoSDKConfigSchema.parse(config)).not.toThrow();
+    });
+
+    it("rejects non-loopback http server URLs", () => {
+      const config = {
+        oauth: {
+          clientId: "https://example.com/",
+          redirectUri: "https://example.com/callback",
+          scope: "atproto",
+          jwksUri: "https://example.com/jwks.json",
+          jwkPrivate: validJWK,
+        },
+        servers: {
+          pds: "http://example.com:2583",
+        },
+      };
+
+      const result = ATProtoSDKConfigSchema.safeParse(config);
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.issues.some((issue) => issue.message.includes("loopback"))).toBe(true);
+      }
+    });
+
+    it("accepts https server URLs", () => {
+      const config = {
+        oauth: {
+          clientId: "https://example.com/",
+          redirectUri: "https://example.com/callback",
+          scope: "atproto",
+          jwksUri: "https://example.com/jwks.json",
+          jwkPrivate: validJWK,
+        },
+        servers: {
+          pds: "https://bsky.social",
+          sds: "https://sds.hypercerts.org",
+        },
+      };
+
+      expect(() => ATProtoSDKConfigSchema.parse(config)).not.toThrow();
+    });
+  });
+
+  describe("developmentMode flag", () => {
+    it("accepts developmentMode: true", () => {
+      const config = {
+        oauth: {
+          clientId: "http://localhost/",
+          redirectUri: "http://127.0.0.1:3000/callback",
+          scope: "atproto",
+          jwksUri: "http://127.0.0.1:3000/jwks.json",
+          jwkPrivate: validJWK,
+          developmentMode: true,
+        },
+      };
+
+      expect(() => ATProtoSDKConfigSchema.parse(config)).not.toThrow();
+    });
+
+    it("accepts developmentMode: false", () => {
+      const config = {
+        oauth: {
+          clientId: "http://localhost/",
+          redirectUri: "http://127.0.0.1:3000/callback",
+          scope: "atproto",
+          jwksUri: "http://127.0.0.1:3000/jwks.json",
+          jwkPrivate: validJWK,
+          developmentMode: false,
+        },
+      };
+
+      expect(() => ATProtoSDKConfigSchema.parse(config)).not.toThrow();
+    });
+
+    it("accepts missing developmentMode (optional)", () => {
+      const config = {
+        oauth: {
+          clientId: "http://localhost/",
+          redirectUri: "http://127.0.0.1:3000/callback",
+          scope: "atproto",
+          jwksUri: "http://127.0.0.1:3000/jwks.json",
+          jwkPrivate: validJWK,
+        },
+      };
+
+      expect(() => ATProtoSDKConfigSchema.parse(config)).not.toThrow();
+    });
+  });
+
+  describe("mixed configurations", () => {
+    it("accepts loopback clientId with https redirectUri", () => {
+      const config = {
+        oauth: {
+          clientId: "http://localhost/",
+          redirectUri: "https://example.com/callback",
+          scope: "atproto",
+          jwksUri: "https://example.com/jwks.json",
+          jwkPrivate: validJWK,
+        },
+      };
+
+      expect(() => ATProtoSDKConfigSchema.parse(config)).not.toThrow();
+    });
+
+    it("accepts https clientId with loopback for local testing servers", () => {
+      const config = {
+        oauth: {
+          clientId: "https://example.com/",
+          redirectUri: "https://example.com/callback",
+          scope: "atproto",
+          jwksUri: "https://example.com/jwks.json",
+          jwkPrivate: validJWK,
+        },
+        servers: {
+          pds: "http://localhost:2583", // Testing against local PDS
+        },
+      };
+
+      expect(() => ATProtoSDKConfigSchema.parse(config)).not.toThrow();
+    });
+  });
+});

--- a/packages/sdk-react/README.md
+++ b/packages/sdk-react/README.md
@@ -51,14 +51,7 @@ const atproto = createATProtoReact({
 });
 
 // 2. Export hooks
-export const {
-  Provider,
-  queryClient,
-  useAuth,
-  useProfile,
-  useOrganizations,
-  useHypercerts,
-} = atproto;
+export const { Provider, queryClient, useAuth, useProfile, useOrganizations, useHypercerts } = atproto;
 
 // 3. Wrap app with QueryClientProvider
 function App() {
@@ -96,7 +89,7 @@ const atproto = createATProtoReact({ config, queryClient });
       <App />
     </atproto.Provider>
   </WagmiProvider>
-</QueryClientProvider>
+</QueryClientProvider>;
 ```
 
 ## Hooks API
@@ -135,7 +128,7 @@ test("renders profile", () => {
   render(
     <TestProvider mockSession={createMockSession({ handle: "test.bsky.social" })}>
       <ProfileComponent />
-    </TestProvider>
+    </TestProvider>,
   );
 });
 ```

--- a/packages/sdk-react/src/factory/createATProtoReact.tsx
+++ b/packages/sdk-react/src/factory/createATProtoReact.tsx
@@ -185,6 +185,27 @@ export interface ATProtoReactInstance {
  * });
  * const atproto = createATProtoReact({ config, queryClient });
  * ```
+ *
+ * @example Local Development
+ * ```typescript
+ * // For local development, use HTTP loopback URLs
+ * const atproto = createATProtoReact({
+ *   config: {
+ *     oauth: {
+ *       clientId: "http://localhost/",
+ *       redirectUri: "http://127.0.0.1:3000/api/auth/callback",
+ *       scope: "atproto",
+ *       jwksUri: "http://127.0.0.1:3000/.well-known/jwks.json",
+ *       jwkPrivate: process.env.ATPROTO_JWK_PRIVATE!,
+ *       developmentMode: true, // Suppresses loopback warnings
+ *     },
+ *     servers: {
+ *       pds: "http://localhost:2583", // Local PDS for testing
+ *     },
+ *     logger: console, // Enable debug logging
+ *   },
+ * });
+ * ```
  */
 export function createATProtoReact(options: CreateATProtoReactOptions): ATProtoReactInstance {
   // Validate options


### PR DESCRIPTION
Why This Was Needed

Previously, developers could not test the Hypercerts SDK locally without deploying to a server with HTTPS certificates. The SDK enforced strict HTTPS-only validation for all OAuth URLs, blocking local development workflows.

However, the underlying `@atproto/oauth-client-node` library **already supports HTTP loopback URLs** as per the [AT Protocol OAuth specification](https://atproto.com/specs/oauth). Our SDK was unnecessarily blocking this capability with overly strict validation.

This PR removes that blocker while maintaining production security.

## Problem Statement

**Before this PR:**
- Could not use `http://localhost` or `http://127.0.0.1` in OAuth configuration
- Developers needed to deploy to staging environments just to test OAuth flows
- No easy way to test against local PDS/SDS instances
- Slower development iteration cycles

**After this PR:**
- Full support for HTTP loopback URLs (`localhost`, `127.0.0.1`, `[::1]`)
- Local testing without HTTPS certificates
- Development mode warnings guide developers appropriately
- Production HTTPS requirements unchanged
- Backward compatible - no breaking changes

## What Changed

### 1. Configuration Schema Updates
- Added custom `urlOrLoopback` Zod validator that accepts:
  - All HTTPS URLs (production)
  - `http://localhost` (with optional port/path)
  - `http://127.0.0.1` (with optional port/path)
  - `http://[::1]` (IPv6 loopback)
- Added optional `developmentMode` flag to suppress warnings
- Updated `OAuthConfigSchema` and `ServerConfigSchema`

### 2. OAuth Client Enhancements
- Added loopback detection in `OAuthClient.buildClientMetadata()`
- Intelligent warnings when loopback URLs used without `developmentMode: true`
- Helpful info logs indicating development mode is active

### 3. Testing
- 28 new unit tests covering all loopback URL patterns
- All 518 tests passing (382 in sdk-core, 136 in sdk-react)
- Test coverage maintained above 70%

### 4. Documentation
- Comprehensive "Local Development" section in sdk-core README
- Complete NextJS App Router example with OAuth setup
- API route implementations (callback, JWKS endpoint)
- Production safety warnings

## OAuth Flow with Loopback URLs

```mermaid
sequenceDiagram
    participant Dev as Developer
    participant App as NextJS App<br/>(localhost:3000)
    participant SDK as Hypercerts SDK
    participant PDS as PDS/Auth Server<br/>(localhost:2583)

    Note over Dev,PDS: Local Development Setup
    
    Dev->>App: Configure SDK with loopback URLs
    Note over App: clientId: http://localhost/<br/>redirectUri: http://127.0.0.1:3000/callback<br/>jwksUri: http://127.0.0.1:3000/.well-known/jwks.json
    
    App->>SDK: sdk.authorize("user.bsky.social")
    SDK->>SDK: Detect loopback URLs<br/>Log: "Running in development mode"
    SDK->>PDS: Authorization request with loopback redirect
    
    PDS->>Dev: Redirect to login page
    Dev->>PDS: Enter credentials
    
    PDS->>SDK: Validate loopback redirect<br/>(ignores port, validates path)
    PDS->>App: Redirect to http://127.0.0.1:3000/callback?code=...
    
    App->>SDK: sdk.callback(params)
    SDK->>App: Fetch JWKS from http://127.0.0.1:3000/.well-known/jwks.json
    SDK->>PDS: Token exchange (DPoP + PKCE)
    PDS->>SDK: Access token + Refresh token
    
    SDK->>App: Return authenticated session
    App->>Dev: Local development continues!
    
    Note over Dev,PDS: Full OAuth flow with HTTP loopback
```

## Example Configuration

### Before (Production Only)
```typescript
const sdk = createATProtoSDK({
  oauth: {
    clientId: "https://your-app.com/client-metadata.json", // HTTPS required
    redirectUri: "https://your-app.com/callback",          // HTTPS required
    jwksUri: "https://your-app.com/jwks.json",             // HTTPS required
    scope: "atproto",
    jwkPrivate: process.env.ATPROTO_JWK_PRIVATE!,
  },
});
```

### After (Development + Production)
```typescript
// Local Development
const sdk = createATProtoSDK({
  oauth: {
    clientId: "http://localhost/",                              // HTTP loopback allowed
    redirectUri: "http://127.0.0.1:3000/api/auth/callback",    // HTTP loopback allowed
    jwksUri: "http://127.0.0.1:3000/.well-known/jwks.json",    // HTTP loopback allowed
    scope: "atproto",
    jwkPrivate: process.env.ATPROTO_JWK_PRIVATE!,
    developmentMode: true, // Suppress warnings
  },
  servers: {
    pds: "http://localhost:2583", // Local PDS
  },
  logger: console,
});
```

## Security Considerations

### What's Safe
- Loopback URLs only accepted for `localhost`, `127.0.0.1`, `[::1]`
- HTTPS still required for all other domains
- DPoP token binding still enforced
- PKCE protection still active
- Production deployments unaffected

### Developer Guidance
- Warning logged when loopback URLs used without `developmentMode: true`
- Info logs indicate when development mode is active
- Documentation emphasizes production HTTPS requirement

### No Compromise
- Authorization server still validates all redirects
- Token security mechanisms unchanged
- JWK validation unchanged
- Session encryption unchanged

## Resources

- **AT Protocol OAuth Specification**: https://atproto.com/specs/oauth
  - Section: "Loopback Interface Redirection" (optional feature)
  - Servers may support `http://localhost/` client_id for development
  - Port numbers ignored during redirect URI validation

- **OAuth Client Implementation Guide**: https://docs.bsky.app/docs/advanced-guides/oauth-client
  - Bluesky's official guide for implementing OAuth clients
  - Includes loopback client patterns

- **@atproto/oauth-client-node**: https://www.npmjs.com/package/@atproto/oauth-client-node
  - The underlying library that handles OAuth flows
  - Already supports loopback URLs per AT Protocol spec

- **RFC 8252 (OAuth for Native Apps)**: https://tools.ietf.org/html/rfc8252#section-8.3
  - Loopback interface redirection for native applications
  - Security considerations for localhost OAuth

## Testing

- All existing tests pass (518 total)
- 28 new unit tests for loopback URL validation
- Test coverage maintained above 70%
- No integration tests needed (responsibility lies with `@atproto/oauth-client-node`)

## Backward Compatibility

- **No breaking changes** - fully backward compatible
- Existing HTTPS configurations work unchanged
- No migration required for existing applications
- Optional `developmentMode` flag (defaults to `false`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * HTTP loopback URL support for local development (localhost, 127.0.0.1, IPv6 ::1)
  * Added optional developmentMode flag and isLoopbackUrl() helper
  * New TypeScript URL types: LoopbackUrl, HttpsUrl, DevelopmentOrProductionUrl

* **Documentation**
  * Local development guides, Next.js examples, API route and JWKS snippets, production notes

* **Tests**
  * Extensive new tests covering loopback validation and configuration scenarios (large test additions)

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->