### PR TITLE
# ci(release): consolidate early checks into single pnpm check step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,8 +58,10 @@ jobs:
       - run: npm install -g npm@latest
 
       - run: pnpm install
-      - run: pnpm build
-      - run: pnpm test
+      # Run checks early to fail fast before any versioning/git operations.
+      # Note: checks run again in `pnpm release` - this is intentional to also
+      # guard local releases and catch any issues after version bumps.
+      - run: pnpm check
 
       # Stable release: Verify prerelease mode has been exited
       # The exit intent should already be set on develop before merging to main


### PR DESCRIPTION
Replace separate `pnpm build` and `pnpm test` steps with `pnpm check` which runs lint, typecheck, build, and test together. Add comment explaining why checks run both here and in `pnpm release`.

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved release pipeline to validate code integrity earlier in the process.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->