### PR TITLE
refactor: centralize URI/Blob handling and improve location attachment

### DIFF
--- a/.changeset/refactor-location-attachment.md
+++ b/.changeset/refactor-location-attachment.md
@@ -1,0 +1,27 @@
+---
+"@hypercerts-org/sdk-core": minor
+---
+
+Refactor location attachment to match lexicon specifications
+
+**New Features:**
+
+- Add `AttachLocationParams` interface exported from SDK for type-safe location attachment
+- Location data now properly uses `org.hypercerts.defs#uri` (for string URIs) or `org.hypercerts.defs#smallBlob` (for
+  GeoJSON blobs) to match lexicon spec
+- Add `lpVersion` and `locationType` fields to location parameters for better protocol compliance
+
+**Improvements:**
+
+- Centralized blob upload logic with new `handleBlobUpload()` helper method
+- Simplified location type detection - now based on content type (string vs Blob) instead of separate `geojson`
+  parameter
+- Improved type safety with structured `AttachLocationParams` interface
+
+**Breaking Changes:**
+
+- `attachLocation()` signature changed from `(uri, { value, name?, description?, srs, geojson? })` to
+  `(uri, AttachLocationParams)`
+- `AttachLocationParams` now requires: `lpVersion`, `srs`, `locationType`, and `location` (string | Blob)
+- The `location` field in `CreateHypercertParams` now uses `AttachLocationParams` type instead of inline object
+- Removed separate `value` and `geojson` fields - use single `location` field with either string or Blob

--- a/packages/sdk-core/src/index.ts
+++ b/packages/sdk-core/src/index.ts
@@ -38,6 +38,7 @@ export type {
   CreateHypercertResult,
   CreateHypercertEvidenceParams,
   CreateOrganizationParams,
+  AttachLocationParams,
 } from "./repository/interfaces.js";
 
 // ============================================================================

--- a/packages/sdk-core/src/repository/HypercertOperationsImpl.ts
+++ b/packages/sdk-core/src/repository/HypercertOperationsImpl.ts
@@ -27,6 +27,7 @@ import {
 } from "../services/hypercerts/types.js";
 import type {
   CreateHypercertEvidenceParams,
+  AttachLocationParams,
   CreateHypercertParams,
   CreateHypercertResult,
   HypercertEvents,
@@ -310,7 +311,7 @@ export class HypercertOperationsImpl extends EventEmitter<HypercertEvents> imple
    */
   private async attachLocationWithProgress(
     hypercertUri: string,
-    location: { value: string; name?: string; description?: string; srs?: string; geojson?: Blob },
+    location: AttachLocationParams,
     onProgress?: (step: ProgressStep) => void,
   ): Promise<string> {
     this.emitProgress(onProgress, { name: "attachLocation", status: "start" });
@@ -839,12 +840,8 @@ export class HypercertOperationsImpl extends EventEmitter<HypercertEvents> imple
    * });
    * ```
    */
-  async attachLocation(
-    hypercertUri: string,
-    location: { value: string; name?: string; description?: string; srs?: string; geojson?: Blob },
-  ): Promise<CreateResult> {
+  async attachLocation(hypercertUri: string, location: AttachLocationParams): Promise<CreateResult> {
     try {
-      // Validate required srs field
       if (!location.srs) {
         throw new ValidationError(
           "srs (Spatial Reference System) is required. Example: 'EPSG:4326' for WGS84 coordinates, or 'http://www.opengis.net/def/crs/OGC/1.3/CRS84' for CRS84.",
@@ -855,43 +852,13 @@ export class HypercertOperationsImpl extends EventEmitter<HypercertEvents> imple
       await this.get(hypercertUri);
       const createdAt = new Date().toISOString();
 
-      // Determine location type and prepare location data
-      let locationData: { $type: string; uri: string } | JsonBlobRef;
-      let locationType: string;
+      const locationData = await this.resolveUriOrBlob(location.location, "application/geo+json");
 
-      if (location.geojson) {
-        // Upload GeoJSON as a blob
-        const arrayBuffer = await location.geojson.arrayBuffer();
-        const uint8Array = new Uint8Array(arrayBuffer);
-        const uploadResult = await this.agent.com.atproto.repo.uploadBlob(uint8Array, {
-          encoding: location.geojson.type || "application/geo+json",
-        });
-        if (uploadResult.success) {
-          locationData = {
-            $type: "blob",
-            ref: { $link: uploadResult.data.blob.ref.toString() },
-            mimeType: uploadResult.data.blob.mimeType,
-            size: uploadResult.data.blob.size,
-          };
-          locationType = "geojson-point";
-        } else {
-          throw new NetworkError("Failed to upload GeoJSON blob");
-        }
-      } else {
-        // Use value as a URI reference
-        locationData = {
-          $type: "org.hypercerts.defs#uri",
-          uri: location.value,
-        };
-        locationType = "coordinate-decimal";
-      }
-
-      // Build location record according to app.certified.location lexicon
       const locationRecord: HypercertLocation = {
         $type: HYPERCERT_COLLECTIONS.LOCATION,
-        lpVersion: "1.0",
+        lpVersion: location.lpVersion || "1.0",
         srs: location.srs,
-        locationType,
+        locationType: location.locationType,
         location: locationData,
         createdAt,
         name: location.name,
@@ -906,12 +873,23 @@ export class HypercertOperationsImpl extends EventEmitter<HypercertEvents> imple
       const result = await this.agent.com.atproto.repo.createRecord({
         repo: this.repoDid,
         collection: HYPERCERT_COLLECTIONS.LOCATION,
-        record: locationRecord as Record<string, unknown>,
+        record: locationRecord,
       });
 
       if (!result.success) {
         throw new NetworkError("Failed to attach location");
       }
+
+      await this.update({
+        uri: hypercertUri,
+        updates: {
+          location: {
+            $type: "com.atproto.repo.strongRef",
+            uri: result.data.uri,
+            cid: result.data.cid,
+          },
+        },
+      });
 
       this.emit("locationAttached", { uri: result.data.uri, cid: result.data.cid, hypercertUri });
       return { uri: result.data.uri, cid: result.data.cid };
@@ -922,26 +900,26 @@ export class HypercertOperationsImpl extends EventEmitter<HypercertEvents> imple
   }
 
   /**
-   * Helper function to get the content of a hypercert evidence.
+   * Generic helper to resolve string | Blob into a URI or blob reference.
    *
-   * @param content - Blob | string
-   * @returns Promise resolving to HypercertEvidence["content"]
+   * @param content - Either a URI string or a Blob to upload
+   * @param fallbackMimeType - MIME type to use if Blob.type is empty
+   * @returns Promise resolving to either a URI ref or blob ref union type
+   * @internal
    */
-  private async getHypercertEvidenceContent(content: CreateHypercertEvidenceParams["content"]) {
-    let evidenceContent: HypercertEvidence["content"];
+  private async resolveUriOrBlob(content: string | Blob, fallbackMimeType: string) {
     if (typeof content === "string") {
-      evidenceContent = {
-        $type: "org.hypercerts.defs#uri",
+      return {
+        $type: "org.hypercerts.defs#uri" as const,
         uri: content,
       };
     } else {
-      const uploadedBlob = await this.handleBlobUpload(content, "application/octet-stream");
-      evidenceContent = {
-        $type: "org.hypercerts.defs#smallBlob",
+      const uploadedBlob = await this.handleBlobUpload(content, fallbackMimeType);
+      return {
+        $type: "org.hypercerts.defs#smallBlob" as const,
         blob: uploadedBlob,
       };
     }
-    return evidenceContent;
   }
 
   /**
@@ -970,7 +948,7 @@ export class HypercertOperationsImpl extends EventEmitter<HypercertEvents> imple
       const subject = await this.get(subjectUri);
       const createdAt = new Date().toISOString();
 
-      const evidenceContent = await this.getHypercertEvidenceContent(content);
+      const evidenceContent = await this.resolveUriOrBlob(content, "application/octet-stream");
       const evidenceRecord: HypercertEvidence = {
         ...rest,
         $type: HYPERCERT_COLLECTIONS.EVIDENCE,

--- a/packages/sdk-core/src/repository/interfaces.ts
+++ b/packages/sdk-core/src/repository/interfaces.ts
@@ -175,38 +175,7 @@ export interface CreateHypercertParams {
   /**
    * Optional geographic location of the impact.
    */
-  location?: {
-    /**
-     * Location value/address.
-     *
-     * @example "San Francisco, CA, USA"
-     */
-    value: string;
-
-    /**
-     * Human-readable location name.
-     *
-     * @example "SF Bay Area"
-     */
-    name?: string;
-
-    /**
-     * Description of the location scope.
-     */
-    description?: string;
-
-    /**
-     * Spatial Reference System identifier (required if location is provided).
-     *
-     * @example "EPSG:4326" for WGS84
-     */
-    srs: string;
-
-    /**
-     * GeoJSON file as a Blob for precise boundaries.
-     */
-    geojson?: Blob;
-  };
+  location?: AttachLocationParams;
 
   /**
    * Optional list of contributions to the impact.
@@ -306,6 +275,50 @@ export interface CreateHypercertEvidenceParams {
    * Any additional custom fields supported by the record.
    */
   [k: string]: unknown;
+}
+
+/**
+ * Parameters for attaching a location to a hypercert.
+ *
+ * @example Using a string location
+ * ```typescript
+ * const params: AttachLocationParams = {
+ *   lpVersion: "1.0.0",
+ *   srs: "EPSG:4326",
+ *   locationType: "coordinate-decimal",
+ *   location: "https://locationuri.com",
+ *   name: "San Francisco",
+ *   description: "Project location in SF Bay Area",
+ * };
+ * ```
+ *
+ * @example Using a GeoJSON Blob
+ * ```typescript
+ * const geojsonBlob = new Blob(
+ *   [JSON.stringify({ type: "Point", coordinates: [-122.4194, 37.7749] })],
+ *   { type: "application/geo+json" }
+ * );
+ * const params: AttachLocationParams = {
+ *   lpVersion: "1.0.0",
+ *   srs: "EPSG:4326",
+ *   locationType: "geojson-point",
+ *   location: geojsonBlob,
+ * };
+ * ```
+ */
+export interface AttachLocationParams {
+  /** The version of the Location Protocol */
+  lpVersion: string;
+  /** The Spatial Reference System URI (e.g., http://www.opengis.net/def/crs/OGC/1.3/CRS84) that defines the coordinate system. */
+  srs: string;
+  /** An identifier for the format of the location data (e.g., coordinate-decimal, geojson-point) */
+  locationType: "coordinate-decimal" | "geojson-point" | (string & {});
+  /** Location data as either a URL string or a GeoJSON Blob */
+  location: string | Blob;
+  /** Optional name for this location */
+  name?: string;
+  /** Optional description for this location */
+  description?: string;
 }
 
 /**
@@ -743,16 +756,7 @@ export interface HypercertOperations extends EventEmitter<HypercertEvents> {
    * @param location.geojson - Optional GeoJSON blob for precise boundaries
    * @returns Promise resolving to location record result
    */
-  attachLocation(
-    uri: string,
-    location: {
-      value: string;
-      name?: string;
-      description?: string;
-      srs: string;
-      geojson?: Blob;
-    },
-  ): Promise<CreateResult>;
+  attachLocation(uri: string, location: AttachLocationParams): Promise<CreateResult>;
 
   /**
    * Adds evidence to an existing hypercert.

--- a/packages/sdk-core/tests/repository/HypercertOperationsImpl.test.ts
+++ b/packages/sdk-core/tests/repository/HypercertOperationsImpl.test.ts
@@ -153,7 +153,7 @@ describe("HypercertOperationsImpl", () => {
         })
         .mockResolvedValueOnce({
           success: true,
-          data: { uri: "at://did:plc:test/org.hypercerts.claim.location/ghi", cid: "location-cid" },
+          data: { uri: "at://did:plc:test/app.certified.location/ghi", cid: "location-cid" },
         });
 
       // Mock getRecord for attachLocation's internal get call
@@ -177,12 +177,25 @@ describe("HypercertOperationsImpl", () => {
         },
       });
 
-      const result = await hypercertOps.create({
-        ...validParams,
-        location: { value: "New York, NY", srs: "EPSG:4326" },
+      // Mock putRecord for the update call
+      mockAgent.com.atproto.repo.putRecord.mockResolvedValue({
+        success: true,
+        data: { uri: "at://did:plc:test/org.hypercerts.claim.record/def", cid: "updated-cid" },
       });
 
-      expect(result.locationUri).toBe("at://did:plc:test/org.hypercerts.claim.location/ghi");
+      const result = await hypercertOps.create({
+        ...validParams,
+        location: {
+          lpVersion: "1.0.0",
+          srs: "EPSG:4326",
+          locationType: "coordinate-decimal",
+          location: "https://example.com/location",
+          name: "Test Location",
+          description: "A test location",
+        },
+      });
+
+      expect(result.locationUri).toBe("at://did:plc:test/app.certified.location/ghi");
     });
 
     it("should create contributions when provided", async () => {
@@ -488,6 +501,92 @@ describe("HypercertOperationsImpl", () => {
       });
 
       expect(handler).toHaveBeenCalled();
+    });
+  });
+
+  describe("attachLocation", () => {
+    beforeEach(() => {
+      mockAgent.com.atproto.repo.getRecord.mockResolvedValue({
+        success: true,
+        data: {
+          uri: "at://did:plc:test/org.hypercerts.claim.record/abc",
+          cid: "hypercert-cid",
+          value: {
+            title: "Test",
+            description: "Test",
+            workScope: {
+              withinAllOf: ["Climate"],
+              withinAnyOf: [],
+              withinNoneOf: [],
+            },
+            startDate: "2024-01-01",
+            endDate: "2024-12-31",
+            createdAt: "2024-01-01",
+          },
+        },
+      });
+
+      // Add this mock for putRecord
+      mockAgent.com.atproto.repo.putRecord.mockResolvedValue({
+        success: true,
+        data: { uri: "at://did:plc:test/org.hypercerts.claim.record/abc", cid: "updated-cid" },
+      });
+
+      mockAgent.com.atproto.repo.createRecord.mockResolvedValue({
+        success: true,
+        data: { uri: "at://did:plc:test/org.hypercerts.claim.location/xyz", cid: "location-cid" },
+      });
+    });
+
+    it("should attach a location using a string URI", async () => {
+      const hypercertUri = "at://did:plc:test/org.hypercerts.claim.record/abc";
+      const result = await hypercertOps.attachLocation(hypercertUri, {
+        lpVersion: "1.0.0",
+        locationType: "coordinate-decimal",
+        location: "https://example.com/location",
+        srs: "EPSG:4326",
+      });
+
+      expect(result.uri).toContain("location");
+      const call = mockAgent.com.atproto.repo.createRecord.mock.calls[0][0];
+      expect(call.record.location).toEqual({
+        $type: "org.hypercerts.defs#uri",
+        uri: "https://example.com/location",
+      });
+    });
+    it("should attach a location using a GeoJSON Blob", async () => {
+      const hypercertUri = "at://did:plc:test/org.hypercerts.claim.record/abc";
+      const blob = new Blob([JSON.stringify({ type: "Point", coordinates: [0, 0] })], {
+        type: "application/geo+json",
+      });
+      mockAgent.com.atproto.repo.uploadBlob.mockResolvedValue({
+        success: true,
+        data: {
+          blob: { ref: { $link: "blob-cid" }, mimeType: "application/geo+json", size: 100 },
+        },
+      });
+
+      const result = await hypercertOps.attachLocation(hypercertUri, {
+        lpVersion: "1.0.0",
+        locationType: "coordinate-decimal",
+        location: blob,
+        srs: "EPSG:4326",
+      });
+
+      expect(result.uri).toContain("location");
+      expect(mockAgent.com.atproto.repo.uploadBlob).toHaveBeenCalled();
+
+      // Check the location record that was created
+      const call = mockAgent.com.atproto.repo.createRecord.mock.calls[0][0];
+      expect(call.record.location).toEqual({
+        $type: "org.hypercerts.defs#smallBlob", // Your code wraps it in smallBlob
+        blob: {
+          // The actual blob data is nested here
+          ref: { $link: "blob-cid" },
+          mimeType: "application/geo+json",
+          size: 100,
+        },
+      });
     });
   });
 


### PR DESCRIPTION
## Summary
Introduces a generic `resolveUriOrBlob` helper to eliminate code duplication when handling `string | Blob` content. 

Update attachLocation params to match latest lexicon along with handling file/blob uploads

## Dependency Note
This PR includes commits from PR #84 (Evidence creation) plus additional location refactoring. The PRs can be reviewed in parallel, but this should be merged after #84 to avoid conflicts.
To view location-only changes, review commits `61cc19a` and `98d18c9`.
## Changes
 ### Core Refactoring
Added `resolveUriOrBlob(content: string | Blob, fallbackMimeType: string)` helper that:
- Returns `{ $type: "org.hypercerts.defs#uri", uri: string }` for string inputs
- Returns `{ $type: "org.hypercerts.defs#smallBlob", blob: BlobRef }` for Blob inputs

This helper is used by both `attachLocation` and `addEvidence` operations, eliminating ~25 lines of duplicated blob upload logic.

 ### Location Attachment
- Removed inline blob upload code from `attachLocation` method
- Location records now properly linked to hypercerts via strongRef
- Updated to match lexicon specification
## Breaking Changes
 AttachLocationParams Interface

**Before:**

```
attachLocation(uri, { 
  value: "San Francisco", 
  srs: "EPSG:4326", 
  geojson: blob  // optional separate field
})
```
After:
```
attachLocation(uri, { 
  lpVersion: "1.0",
  srs: "EPSG:4326", 
  locationType: "coordinate-decimal",
  location: "San Francisco"  // unified field: string | Blob
})
```
## Changes:
- Removed value field
- Removed geojson field
- Added unified location: string | Blob field
- Added required lpVersion field
- Added required locationType field
## Related
- Depends on: #84
- Closes: #77
- Supersedes: #90

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Breaking Changes**
  * Location attachment API updated: `attachLocation()` method now requires `lpVersion` and `locationType` parameters, and uses a consolidated `location` field (string or Blob) replacing separate value and geojson parameters.

* **Improvements**
  * Enhanced type safety and consistency for location data handling across SDK operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->