### PR TITLE
fix: align collection/project CRUD types with lexicon definitions

### DIFF
--- a/.changeset/align-collection-project-types.md
+++ b/.changeset/align-collection-project-types.md
@@ -1,0 +1,72 @@
+---
+"@hypercerts-org/sdk-core": minor
+---
+
+feat: align collection/project types with lexicon + add inline location support
+
+This is a BREAKING change.
+
+**Type Alignment with Lexicon:**
+
+- Changed `createCollection` to use lexicon-aligned `items` array instead of `claims`
+- Updated avatar/banner handling to use proper lexicon union types
+- Simplified project methods to delegate to collection methods
+- Added `CreateCollectionParams`, `UpdateCollectionParams`, and result types derived from lexicon
+- Improved type safety by deriving SDK input types from lexicon definitions
+
+**Inline Location Support:**
+
+`AttachLocationParams` now supports three ways to specify location:
+
+1. **StrongRef** - Direct reference with uri and cid (no record creation)
+2. **AT-URI string** - Reference to existing location record
+3. **Location object** - Full location data to create a new location record
+
+**Changes:**
+
+- Add `AttachLocationParams` union type supporting StrongRef, string URI, or location object
+- Add optional `location` field to `CreateCollectionParams`
+- Add optional `location` field to `UpdateCollectionParams` (supports `null` to remove)
+- Update `CreateCollectionResult` to include optional `locationUri` field
+- Implement location handling in `createCollection()` - supports all three forms
+- Add tests for collection creation with StrongRef, string URI, and location object
+
+**Example Usage:**
+
+```typescript
+// Create a project with location (StrongRef - direct reference)
+const project = await repo.hypercerts.createProject({
+  title: "Climate Initiative",
+  items: [...],
+  location: { uri: "at://did:plc:alice/app.certified.location/abc", cid: "bafy..." },
+});
+
+// Create with location (AT-URI string - fetches CID)
+const project2 = await repo.hypercerts.createProject({
+  title: "Forest Project",
+  items: [...],
+  location: "at://did:plc:bob/app.certified.location/xyz",
+});
+
+// Create with location (location object - creates new record)
+const project3 = await repo.hypercerts.createProject({
+  title: "Ocean Project",
+  items: [...],
+  location: {
+    lpVersion: "1.0",
+    srs: "EPSG:4326",
+    locationType: "coordinate-decimal",
+    location: "37.7749, -122.4194",
+  },
+});
+
+// Update project to change location
+await repo.hypercerts.updateProject(project.uri, {
+  location: "at://did:plc:alice/app.certified.location/new",
+});
+
+// Remove location
+await repo.hypercerts.updateProject(project.uri, {
+  location: null,
+});
+```

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -7,6 +7,7 @@
       "Bash(pnpm lint:*)",
       "Bash(pnpm test:*)",
       "Bash(pnpm typecheck:*)"
-    ]
+    ],
+    "deny": ["Bash(npm:*)", "Bash(yarn:*)"]
   }
 }

--- a/.claude/skills/writing-changesets/SKILL.md
+++ b/.claude/skills/writing-changesets/SKILL.md
@@ -1,0 +1,154 @@
+---
+name: writing-changesets
+description:
+  Create changeset files for user-facing changes. Use when making API changes, modifying types, adding features, or any
+  change that affects package consumers.
+---
+
+# Writing Changesets
+
+Create a changeset file to document user-facing changes for release.
+
+## When to Use
+
+Add a changeset when making changes that affect consumers:
+
+- Adding new SDK methods or operations (createProject, addEvidence, etc.)
+- Modifying existing API signatures (breaking or non-breaking)
+- Changing TypeScript type exports or interfaces
+- Adding new React hooks or components
+- Renaming any exported constants, types, functions, or hooks
+- Changing behavior of existing operations
+- Bug fixes that affect external behavior
+- Any change that requires a version bump or affects package consumers
+
+Skip changesets for internal changes (build scripts, tests, refactoring, documentation only).
+
+## Packages
+
+The SDK has two publishable packages:
+
+- `@hypercerts-org/sdk-core` - Core SDK
+- `@hypercerts-org/sdk-react` - React hooks etc.
+
+## Format
+
+Create in `.changeset/` a Markdown file with a descriptive kebab-case name (e.g., `fix-collection-type-alignment.md`) in
+this format:
+
+```markdown
+---
+"@hypercerts-org/sdk-core": minor
+---
+
+Align collection/project CRUD types with lexicon definitions
+```
+
+For changes affecting both packages:
+
+```markdown
+---
+"@hypercerts-org/sdk-core": minor
+"@hypercerts-org/sdk-react": minor
+---
+
+Add comprehensive project support to SDK
+
+**Core SDK (`@hypercerts-org/sdk-core`):**
+
+- Add project CRUD operations (createProject, getProject, listProjects)
+- Add project events (projectCreated, projectUpdated, projectDeleted)
+- Support for avatar and banner blob uploads
+
+**React SDK (`@hypercerts-org/sdk-react`):**
+
+- Add useProjects and useProject hooks
+- Project query keys for cache management
+- TypeScript types for projects
+```
+
+### Frontmatter Fields
+
+There should be a frontmatter field for each package being changed. The field name should be the package name, and the
+field value should be one of the following change types:
+
+- `patch` - Bug fixes, non-breaking changes
+- `minor` - New features, non-breaking additions (also breaking changes if the version in `package.json` is still 0.x.y)
+- `major` - Breaking changes (_ONLY_ use if the version in `package.json` is already greater than 0.x.y)
+
+**Current versions are 0.x.y, so use `minor` for breaking changes.**
+
+### Description
+
+In the body after the frontmatter field(s), write a clear, concise description following conventional commit style.
+Focus on what changed and why. For multi-package changes, use sections to separate changes.
+
+## Example Changesets
+
+**New SDK feature:**
+
+```markdown
+---
+"@hypercerts-org/sdk-core": minor
+---
+
+Add project CRUD operations to repository interface
+```
+
+**API signature change:**
+
+```markdown
+---
+"@hypercerts-org/sdk-core": minor
+---
+
+Evidence records are now created separately instead of being embedded inline in hypercerts
+
+**Breaking Changes:**
+
+- Evidence is no longer embedded in the hypercert record - use `result.evidenceUris` to access evidence record URIs
+- `addEvidence()` now accepts a single `CreateHypercertEvidenceParams` object instead of
+  `(uri: string, evidence: HypercertEvidence[])`
+```
+
+**Type/interface change:**
+
+```markdown
+---
+"@hypercerts-org/sdk-core": minor
+---
+
+Align collection/project CRUD types with lexicon definitions
+
+- Update CreateCollectionParams to match lexicon schema
+- Add CreateCollectionResult type with optional location URI
+- Simplify project operations to delegate to collection operations
+```
+
+**React hook addition:**
+
+```markdown
+---
+"@hypercerts-org/sdk-react": minor
+---
+
+Add useProjects and useProject hooks for project management
+```
+
+**Bug fix:**
+
+```markdown
+---
+"@hypercerts-org/sdk-core": patch
+---
+
+Fix SDS routing for organization endpoints
+```
+
+## Key Files
+
+- `.changeset/config.json` - Changeset configuration
+- Existing changeset files in `.changeset/` - Reference for naming and format
+- `package.json` - Contains version and release scripts
+- `packages/sdk-core/package.json` - Core SDK version
+- `packages/sdk-react/package.json` - React SDK version

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ yarn-error.log*
 stats.html
 coverage/
 .npmrc
+tmp/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -217,6 +217,38 @@ Use the error hierarchy in `sdk-core/src/core/errors.ts`:
 - Test files: `*.test.ts` in `tests/` directory
 - Use fixtures from `tests/utils/fixtures.ts`
 
+### SDK Type Design Principles
+
+- Types like `HypercertClaim` should always be used rather than underlying types like `OrgHypercertsClaimActivity.Main`
+  which are exported from the lexicons package
+
+- Whenever an SDK method creates a record, there should be a corresponding type like `CreateCollectionParams` defined,
+  which is derived from `HypercertCollection`, but with `$type` and `createdAt` made optional. Then the method should
+  ensure that those are auto-populated if missing.
+
+- For any methods which can refer to a _potentially_ existing record, e.g. update methods or attach methods like
+  `attachLocationToProject()`, then the user should be able to reference that object in three different ways:
+  1. provide an AT-URI pointing to an existing record
+  2. provide a StrongRef pointing to an existing record
+  3. provide an object of a type named like `Create*Params` where \* can be Collection / Activity etc. as appropriate
+
+  These possibilities should be a union type called something like `CollectionParams`.
+
+- There should also be types like `UpdateCollectionParams` which should be a `Partial` allowing the update methods to
+  perform selective updates on just some parts of the record.
+
+- So in summary, for each lexicon entity type, there should be five types, e.g. for the `org.hypercerts.claim.rights`
+  lexicon there should be:
+  1. `OrgHypercertsClaimRights.Main` (from the lexicon package)
+  2. `HypercertRights` - the same as 1, as syntactic sugar defined by the SDK. These should all be defined in the same
+     place in the same file.
+  3. `CreateRightsParams` - `SetOptional<HypercertRights, "$type" | "createdAt">` should be the basis for this
+     definition. However if the lexicon contains strongRefs to other lexicons, this should be further wrapped with
+     `OverrideProperties` from the `type-fest` package to replace any nested objects with the equivalent `Create*Params`
+     type, so that creation of multiple records can be achieved by calling a single create method for the main record.
+  4. `UpdateRightsParams` - `Partial<CreateRightsParams>`
+  5. `RightsParams` - union type `string | StrongRef | CreateRightsParams`
+
 ## Build Output
 
 ### sdk-core

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -247,22 +247,32 @@ Each entrypoint outputs:
 
 Uses [Changesets](https://github.com/changesets/changesets) for versioning.
 
-**Flow:** `feature` → `develop` (beta) → `main` (stable)
+**Branch flow:** `feature` → `develop` (beta) → `main` (stable)
 
-### Commands
+### Creating Changesets
 
-```bash
-pnpm changeset          # Add changeset (required for package changes)
-pnpm version-packages   # Apply changesets locally
-pnpm release            # Build and publish
-```
+**REQUIRED: All user-facing changes must include a changeset.**
 
-### Branches
+To create a changeset, use the `writing-changesets` skill.
+
+**The skill is the single source of truth for:**
+
+- When changesets are required vs optional
+- How to format changeset files correctly
+- Which packages to include in the frontmatter
+- Changeset type selection (patch/minor/major)
+- Examples for different types of changes
+
+Do not attempt to create changesets without consulting this skill first.
+
+### Release Branches
 
 - **develop**: Auto-publishes `@beta` tag (e.g., `0.2.0-beta.0`)
 - **main**: Creates Release PR → merge to publish `@latest`
 
 ### Before merging develop → main
+
+You should never do this unless explicitly requested by the user:
 
 ```bash
 pnpm changeset pre exit
@@ -357,26 +367,10 @@ git commit -m "feat(hypercerts): add project CRUD operations"
 # - Block commit if build fails
 
 # 6. If prompted, add changeset for user-facing changes
-pnpm changeset
+# See "Release Process" section - use the writing-changesets skill
 git add .changeset/*.md
 git commit -m "chore: add changeset for project operations"
 ```
-
-### When to Add a Changeset
-
-Run `pnpm changeset` before pushing if your changes include:
-
-- New features or API changes
-- Bug fixes that affect users
-- Breaking changes
-- Performance improvements
-
-Skip changesets for:
-
-- Internal refactoring
-- Test-only changes
-- Documentation updates
-- Development tooling changes
 
 ## Key Files Reference
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -30,6 +30,6 @@ export default [
     },
   },
   {
-    ignores: ["**/dist/**", "**/node_modules/**", "**/*.config.*", "**/.rollup.cache/**", "**/coverage/**"],
+    ignores: ["**/dist/**", "**/node_modules/**", "**/.rollup.cache/**", "**/coverage/**", "**/tmp/**"],
   },
 ];

--- a/opencode.json
+++ b/opencode.json
@@ -7,7 +7,9 @@
       "pnpm format*": "allow",
       "pnpm lint*": "allow",
       "pnpm test*": "allow",
-      "pnpm typecheck*": "allow"
+      "pnpm typecheck*": "allow",
+      "npm *": "deny",
+      "yarn *": "deny"
     }
   }
 }

--- a/packages/sdk-core/README.md
+++ b/packages/sdk-core/README.md
@@ -411,7 +411,130 @@ const measurement = await repo.hypercerts.addMeasurement({
 });
 ```
 
-### 5. Blob Operations (Images & Files)
+### 5. Collections and Projects
+
+Collections organize multiple hypercerts into logical groupings. Projects are a special type of collection with
+`type="project"`.
+
+#### Creating a Collection
+
+```typescript
+// Create a collection with weighted items
+const collection = await repo.hypercerts.createCollection({
+  title: "Climate Projects 2024",
+  shortDescription: "Our climate impact portfolio",
+  description: "A curated collection of climate-related hypercerts",
+  items: [
+    {
+      itemIdentifier: { uri: hypercert1Uri, cid: hypercert1Cid },
+      itemWeight: "0.5",
+    },
+    {
+      itemIdentifier: { uri: hypercert2Uri, cid: hypercert2Cid },
+      itemWeight: "0.3",
+    },
+    {
+      itemIdentifier: { uri: hypercert3Uri, cid: hypercert3Cid },
+      itemWeight: "0.2",
+    },
+  ],
+  avatar: avatarBlob, // optional
+  banner: bannerBlob, // optional
+});
+
+console.log("Created collection:", collection.uri);
+```
+
+#### Creating a Project
+
+Projects are collections with automatic `type="project"`:
+
+```typescript
+const project = await repo.hypercerts.createProject({
+  title: "Rainforest Restoration",
+  shortDescription: "Multi-year restoration initiative",
+  description: "Comprehensive rainforest restoration project",
+  items: [
+    {
+      itemIdentifier: { uri: activity1Uri, cid: activity1Cid },
+      itemWeight: "0.6",
+    },
+    {
+      itemIdentifier: { uri: activity2Uri, cid: activity2Cid },
+      itemWeight: "0.4",
+    },
+  ],
+});
+```
+
+#### Attaching Locations
+
+Both collections and projects can have location data attached as a sidecar record:
+
+```typescript
+// Attach location to a project
+const locationResult = await repo.hypercerts.attachLocationToProject(projectUri, {
+  lpVersion: "1.0",
+  srs: "EPSG:4326",
+  locationType: "coordinate-decimal",
+  location: "https://example.com/location.geojson", // or use a Blob
+  name: "Project Site",
+  description: "Main restoration site coordinates",
+});
+
+// Also works for collections
+await repo.hypercerts.attachLocationToCollection(collectionUri, locationParams);
+```
+
+#### Listing and Retrieving
+
+```typescript
+// Get a specific collection
+const collection = await repo.hypercerts.getCollection(collectionUri);
+
+// List all collections
+const { records } = await repo.hypercerts.listCollections();
+
+// Get a specific project
+const project = await repo.hypercerts.getProject(projectUri);
+
+// List all projects
+const { records } = await repo.hypercerts.listProjects();
+```
+
+#### Updating Collections and Projects
+
+```typescript
+// Update collection
+await repo.hypercerts.updateCollection(collectionUri, {
+  title: "Updated Title",
+  items: [
+    /* updated items */
+  ],
+  avatar: newAvatarBlob, // or null to remove
+});
+
+// Update project (same API)
+await repo.hypercerts.updateProject(projectUri, {
+  shortDescription: "Updated description",
+  banner: null, // removes banner
+});
+```
+
+#### Deleting
+
+```typescript
+// Delete collection
+await repo.hypercerts.deleteCollection(collectionUri);
+
+// Delete project
+await repo.hypercerts.deleteProject(projectUri);
+
+// Remove location from project
+await repo.hypercerts.removeLocationFromProject(projectUri);
+```
+
+### 6. Blob Operations (Images & Files)
 
 ```typescript
 // Upload an image or file
@@ -422,7 +545,7 @@ console.log("Blob uploaded:", blobResult.ref.$link);
 const blobData = await repo.blobs.get("did:plc:user123", "bafyreiabc123...");
 ```
 
-### 6. Organizations (SDS only)
+### 7. Organizations (SDS only)
 
 Organizations allow multiple users to collaborate on shared repositories.
 
@@ -450,7 +573,7 @@ const org = await repo.organizations.get("did:plc:org123");
 console.log(`${org.name} - ${org.description}`);
 ```
 
-### 7. Collaborator Management (SDS only)
+### 8. Collaborator Management (SDS only)
 
 Manage who has access to your repository and what they can do.
 
@@ -519,7 +642,7 @@ await repo.collaborators.transferOwnership({
 });
 ```
 
-### 8. Generic Record Operations
+### 9. Generic Record Operations
 
 For working with any ATProto record type:
 
@@ -564,7 +687,7 @@ const { records, cursor } = await repo.records.list({
 });
 ```
 
-### 9. Profile Management (PDS only)
+### 10. Profile Management (PDS only)
 
 ```typescript
 // Get user profile
@@ -584,40 +707,56 @@ await repo.profile.update({
 
 ### Repository Operations
 
-| Operation          | Method                                   | PDS | SDS | Returns                      |
-| ------------------ | ---------------------------------------- | --- | --- | ---------------------------- |
-| **Records**        |                                          |     |     |                              |
-| Create record      | `repo.records.create()`                  | ✅  | ✅  | `{ uri, cid }`               |
-| Get record         | `repo.records.get()`                     | ✅  | ✅  | Record data                  |
-| Update record      | `repo.records.update()`                  | ✅  | ✅  | `{ uri, cid }`               |
-| Delete record      | `repo.records.delete()`                  | ✅  | ✅  | void                         |
-| List records       | `repo.records.list()`                    | ✅  | ✅  | `{ records, cursor? }`       |
-| **Hypercerts**     |                                          |     |     |                              |
-| Create hypercert   | `repo.hypercerts.create()`               | ✅  | ✅  | `{ uri, cid, value }`        |
-| Get hypercert      | `repo.hypercerts.get()`                  | ✅  | ✅  | Full hypercert               |
-| Update hypercert   | `repo.hypercerts.update()`               | ✅  | ✅  | `{ uri, cid }`               |
-| Delete hypercert   | `repo.hypercerts.delete()`               | ✅  | ✅  | void                         |
-| List hypercerts    | `repo.hypercerts.list()`                 | ✅  | ✅  | `{ records, cursor? }`       |
-| Add contribution   | `repo.hypercerts.addContribution()`      | ✅  | ✅  | Contribution                 |
-| Add measurement    | `repo.hypercerts.addMeasurement()`       | ✅  | ✅  | Measurement                  |
-| **Blobs**          |                                          |     |     |                              |
-| Upload blob        | `repo.blobs.upload()`                    | ✅  | ✅  | `{ ref, mimeType, size }`    |
-| Get blob           | `repo.blobs.get()`                       | ✅  | ✅  | Blob data                    |
-| **Profile**        |                                          |     |     |                              |
-| Get profile        | `repo.profile.get()`                     | ✅  | ❌  | Profile data                 |
-| Update profile     | `repo.profile.update()`                  | ✅  | ❌  | void                         |
-| **Organizations**  |                                          |     |     |                              |
-| Create org         | `repo.organizations.create()`            | ❌  | ✅  | `{ did, name, ... }`         |
-| Get org            | `repo.organizations.get()`               | ❌  | ✅  | Organization                 |
-| List orgs          | `repo.organizations.list()`              | ❌  | ✅  | `{ organizations, cursor? }` |
-| **Collaborators**  |                                          |     |     |                              |
-| Grant access       | `repo.collaborators.grant()`             | ❌  | ✅  | void                         |
-| Revoke access      | `repo.collaborators.revoke()`            | ❌  | ✅  | void                         |
-| List collaborators | `repo.collaborators.list()`              | ❌  | ✅  | `{ collaborators, cursor? }` |
-| Check access       | `repo.collaborators.hasAccess()`         | ❌  | ✅  | boolean                      |
-| Get role           | `repo.collaborators.getRole()`           | ❌  | ✅  | Role string                  |
-| Get permissions    | `repo.collaborators.getPermissions()`    | ❌  | ✅  | Permissions                  |
-| Transfer ownership | `repo.collaborators.transferOwnership()` | ❌  | ✅  | void                         |
+| Operation          | Method                                           | PDS | SDS | Returns                      |
+| ------------------ | ------------------------------------------------ | --- | --- | ---------------------------- |
+| **Records**        |                                                  |     |     |                              |
+| Create record      | `repo.records.create()`                          | ✅  | ✅  | `{ uri, cid }`               |
+| Get record         | `repo.records.get()`                             | ✅  | ✅  | Record data                  |
+| Update record      | `repo.records.update()`                          | ✅  | ✅  | `{ uri, cid }`               |
+| Delete record      | `repo.records.delete()`                          | ✅  | ✅  | void                         |
+| List records       | `repo.records.list()`                            | ✅  | ✅  | `{ records, cursor? }`       |
+| **Hypercerts**     |                                                  |     |     |                              |
+| Create hypercert   | `repo.hypercerts.create()`                       | ✅  | ✅  | `{ uri, cid, value }`        |
+| Get hypercert      | `repo.hypercerts.get()`                          | ✅  | ✅  | Full hypercert               |
+| Update hypercert   | `repo.hypercerts.update()`                       | ✅  | ✅  | `{ uri, cid }`               |
+| Delete hypercert   | `repo.hypercerts.delete()`                       | ✅  | ✅  | void                         |
+| List hypercerts    | `repo.hypercerts.list()`                         | ✅  | ✅  | `{ records, cursor? }`       |
+| Add contribution   | `repo.hypercerts.addContribution()`              | ✅  | ✅  | Contribution                 |
+| Add measurement    | `repo.hypercerts.addMeasurement()`               | ✅  | ✅  | Measurement                  |
+| **Collections**    |                                                  |     |     |                              |
+| Create collection  | `repo.hypercerts.createCollection()`             | ✅  | ✅  | `{ uri, cid, record }`       |
+| Get collection     | `repo.hypercerts.getCollection()`                | ✅  | ✅  | Collection data              |
+| List collections   | `repo.hypercerts.listCollections()`              | ✅  | ✅  | `{ records, cursor? }`       |
+| Update collection  | `repo.hypercerts.updateCollection()`             | ✅  | ✅  | `{ uri, cid }`               |
+| Delete collection  | `repo.hypercerts.deleteCollection()`             | ✅  | ✅  | void                         |
+| Attach location    | `repo.hypercerts.attachLocationToCollection()`   | ✅  | ✅  | `{ uri, cid }`               |
+| Remove location    | `repo.hypercerts.removeLocationFromCollection()` | ✅  | ✅  | void                         |
+| **Projects**       |                                                  |     |     |                              |
+| Create project     | `repo.hypercerts.createProject()`                | ✅  | ✅  | `{ uri, cid, record }`       |
+| Get project        | `repo.hypercerts.getProject()`                   | ✅  | ✅  | Project data                 |
+| List projects      | `repo.hypercerts.listProjects()`                 | ✅  | ✅  | `{ records, cursor? }`       |
+| Update project     | `repo.hypercerts.updateProject()`                | ✅  | ✅  | `{ uri, cid }`               |
+| Delete project     | `repo.hypercerts.deleteProject()`                | ✅  | ✅  | void                         |
+| Attach location    | `repo.hypercerts.attachLocationToProject()`      | ✅  | ✅  | `{ uri, cid }`               |
+| Remove location    | `repo.hypercerts.removeLocationFromProject()`    | ✅  | ✅  | void                         |
+| **Blobs**          |                                                  |     |     |                              |
+| Upload blob        | `repo.blobs.upload()`                            | ✅  | ✅  | `{ ref, mimeType, size }`    |
+| Get blob           | `repo.blobs.get()`                               | ✅  | ✅  | Blob data                    |
+| **Profile**        |                                                  |     |     |                              |
+| Get profile        | `repo.profile.get()`                             | ✅  | ❌  | Profile data                 |
+| Update profile     | `repo.profile.update()`                          | ✅  | ❌  | void                         |
+| **Organizations**  |                                                  |     |     |                              |
+| Create org         | `repo.organizations.create()`                    | ❌  | ✅  | `{ did, name, ... }`         |
+| Get org            | `repo.organizations.get()`                       | ❌  | ✅  | Organization                 |
+| List orgs          | `repo.organizations.list()`                      | ❌  | ✅  | `{ organizations, cursor? }` |
+| **Collaborators**  |                                                  |     |     |                              |
+| Grant access       | `repo.collaborators.grant()`                     | ❌  | ✅  | void                         |
+| Revoke access      | `repo.collaborators.revoke()`                    | ❌  | ✅  | void                         |
+| List collaborators | `repo.collaborators.list()`                      | ❌  | ✅  | `{ collaborators, cursor? }` |
+| Check access       | `repo.collaborators.hasAccess()`                 | ❌  | ✅  | boolean                      |
+| Get role           | `repo.collaborators.getRole()`                   | ❌  | ✅  | Role string                  |
+| Get permissions    | `repo.collaborators.getPermissions()`            | ❌  | ✅  | Permissions                  |
+| Transfer ownership | `repo.collaborators.transferOwnership()`         | ❌  | ✅  | void                         |
 
 ## Type System
 

--- a/packages/sdk-core/eslint.config.mjs
+++ b/packages/sdk-core/eslint.config.mjs
@@ -19,4 +19,7 @@ export default [
       },
     },
   },
+  {
+    ignores: ["vitest.config.ts"],
+  },
 ];

--- a/packages/sdk-core/package.json
+++ b/packages/sdk-core/package.json
@@ -88,8 +88,9 @@
     "@atproto/lexicon": "^0.5.1",
     "@atproto/oauth-client": "^0.5.10",
     "@atproto/oauth-client-node": "^0.3.12",
-    "@hypercerts-org/lexicon": "0.10.0-beta.10",
+    "@hypercerts-org/lexicon": "0.10.0-beta.11",
     "eventemitter3": "^5.0.1",
+    "type-fest": "^5.4.1",
     "zod": "^3.24.4"
   }
 }

--- a/packages/sdk-core/src/index.ts
+++ b/packages/sdk-core/src/index.ts
@@ -93,7 +93,7 @@ export type {
   CreateHypercertResult,
   CreateHypercertEvidenceParams,
   CreateOrganizationParams,
-  AttachLocationParams,
+  LocationParams,
 } from "./repository/interfaces.js";
 
 // ============================================================================

--- a/packages/sdk-core/src/repository/HypercertOperationsImpl.ts
+++ b/packages/sdk-core/src/repository/HypercertOperationsImpl.ts
@@ -15,25 +15,35 @@ import { NetworkError, ValidationError } from "../errors.js";
 import type { LoggerInterface } from "../core/interfaces.js";
 import {
   HYPERCERT_COLLECTIONS,
+  type CreateCollectionParams,
+  type CreateCollectionResult,
+  type CreateProjectParams,
+  type CreateProjectResult,
   type HypercertClaim,
   type HypercertCollection,
   type HypercertContributionDetails,
   type HypercertEvaluation,
   type HypercertEvidence,
   type HypercertLocation,
+  type CreateLocationParams,
   type HypercertMeasurement,
   type HypercertRights,
   type JsonBlobRef,
+  type OrgHypercertsDefs,
+  type StrongRef,
+  type UpdateCollectionParams,
+  type UpdateProjectParams,
 } from "../services/hypercerts/types.js";
 import type {
   CreateHypercertEvidenceParams,
-  AttachLocationParams,
+  LocationParams,
   CreateHypercertParams,
   CreateHypercertResult,
   HypercertEvents,
   HypercertOperations,
 } from "./interfaces.js";
 import type { CreateResult, ListParams, PaginatedList, ProgressStep, UpdateResult } from "./types.js";
+import { $Typed } from "@atproto/api";
 
 /**
  * Implementation of high-level hypercert operations.
@@ -311,7 +321,7 @@ export class HypercertOperationsImpl extends EventEmitter<HypercertEvents> imple
    */
   private async attachLocationWithProgress(
     hypercertUri: string,
-    location: AttachLocationParams,
+    location: LocationParams,
     onProgress?: (step: ProgressStep) => void,
   ): Promise<string> {
     this.emitProgress(onProgress, { name: "attachLocation", status: "start" });
@@ -594,7 +604,7 @@ export class HypercertOperationsImpl extends EventEmitter<HypercertEvents> imple
    */
   async update(params: {
     uri: string;
-    updates: Partial<Omit<HypercertClaim, "$type" | "createdAt" | "rights">>;
+    updates: Partial<CreateHypercertParams>;
     image?: Blob | null;
   }): Promise<UpdateResult> {
     try {
@@ -840,59 +850,29 @@ export class HypercertOperationsImpl extends EventEmitter<HypercertEvents> imple
    * });
    * ```
    */
-  async attachLocation(hypercertUri: string, location: AttachLocationParams): Promise<CreateResult> {
+  async attachLocation(hypercertUri: string, location: LocationParams): Promise<CreateResult> {
     try {
-      if (!location.srs) {
-        throw new ValidationError(
-          "srs (Spatial Reference System) is required. Example: 'EPSG:4326' for WGS84 coordinates, or 'http://www.opengis.net/def/crs/OGC/1.3/CRS84' for CRS84.",
-        );
-      }
-
       // Validate that hypercert exists (unused but confirms hypercert is valid)
       await this.get(hypercertUri);
-      const createdAt = new Date().toISOString();
-
-      const locationData = await this.resolveUriOrBlob(location.location, "application/geo+json");
-
-      const locationRecord: HypercertLocation = {
-        $type: HYPERCERT_COLLECTIONS.LOCATION,
-        lpVersion: location.lpVersion || "1.0",
-        srs: location.srs,
-        locationType: location.locationType,
-        location: locationData,
-        createdAt,
-        name: location.name,
-        description: location.description,
-      };
-
-      const validation = validate(locationRecord, HYPERCERT_COLLECTIONS.LOCATION, "main", false);
-      if (!validation.success) {
-        throw new ValidationError(`Invalid location record: ${validation.error?.message}`);
-      }
-
-      const result = await this.agent.com.atproto.repo.createRecord({
-        repo: this.repoDid,
-        collection: HYPERCERT_COLLECTIONS.LOCATION,
-        record: locationRecord,
-      });
-
-      if (!result.success) {
-        throw new NetworkError("Failed to attach location");
-      }
+      const resolvedLocation = await this.resolveLocation(location);
 
       await this.update({
         uri: hypercertUri,
         updates: {
           location: {
             $type: "com.atproto.repo.strongRef",
-            uri: result.data.uri,
-            cid: result.data.cid,
+            uri: resolvedLocation.uri,
+            cid: resolvedLocation.cid,
           },
         },
       });
 
-      this.emit("locationAttached", { uri: result.data.uri, cid: result.data.cid, hypercertUri });
-      return { uri: result.data.uri, cid: result.data.cid };
+      this.emit("locationAttached", {
+        uri: resolvedLocation.uri,
+        cid: resolvedLocation.cid,
+        hypercertUri,
+      });
+      return { uri: resolvedLocation.uri, cid: resolvedLocation.cid };
     } catch (error) {
       if (error instanceof ValidationError || error instanceof NetworkError) throw error;
       throw new NetworkError(`Failed to attach location: ${error instanceof Error ? error.message : "Unknown"}`, error);
@@ -904,22 +884,111 @@ export class HypercertOperationsImpl extends EventEmitter<HypercertEvents> imple
    *
    * @param content - Either a URI string or a Blob to upload
    * @param fallbackMimeType - MIME type to use if Blob.type is empty
-   * @returns Promise resolving to either a URI ref or blob ref union type
+   * @returns Promise resolving to either a URI ref or blob ref
    * @internal
    */
   private async resolveUriOrBlob(content: string | Blob, fallbackMimeType: string) {
     if (typeof content === "string") {
-      return {
-        $type: "org.hypercerts.defs#uri" as const,
+      const uriRef = {
+        $type: "org.hypercerts.defs#uri",
         uri: content,
-      };
-    } else {
-      const uploadedBlob = await this.handleBlobUpload(content, fallbackMimeType);
-      return {
-        $type: "org.hypercerts.defs#smallBlob" as const,
-        blob: uploadedBlob,
-      };
+      } satisfies $Typed<OrgHypercertsDefs.Uri>;
+      return uriRef;
     }
+
+    const uploadedBlob = await this.handleBlobUpload(content, fallbackMimeType);
+    const blobRef = {
+      $type: "org.hypercerts.defs#smallBlob",
+      blob: uploadedBlob,
+    } satisfies $Typed<OrgHypercertsDefs.SmallBlob>;
+    return blobRef;
+  }
+
+  private async resolveCollectionImageInput(input: string | Blob): Promise<NonNullable<HypercertCollection["avatar"]>>;
+  private async resolveCollectionImageInput(
+    input: string | Blob,
+    isBanner: true,
+  ): Promise<NonNullable<HypercertCollection["banner"]>>;
+  private async resolveCollectionImageInput(input: string | Blob, isBanner: boolean = false) {
+    if (typeof input === "string") {
+      return { $type: "org.hypercerts.defs#uri" as const, uri: input };
+    }
+
+    const blob = await this.handleBlobUpload(input, "image/jpeg");
+    if (isBanner) {
+      return { $type: "org.hypercerts.defs#largeImage" as const, image: blob };
+    }
+
+    return { $type: "org.hypercerts.defs#smallImage" as const, image: blob };
+  }
+
+  private async resolveLocationValue(location: string | Blob | HypercertLocation["location"]) {
+    if (typeof location === "string" || location instanceof Blob) {
+      return this.resolveUriOrBlob(location, "application/geo+json");
+    }
+
+    return location;
+  }
+
+  /**
+   * Check if an AttachLocationParams is the object form (not a StrongRef or string).
+   * @internal
+   */
+  private isLocationObject(location: LocationParams): location is CreateLocationParams {
+    return (
+      typeof location === "object" &&
+      !("uri" in location) &&
+      !("cid" in location) &&
+      location !== null &&
+      !Array.isArray(location)
+    );
+  }
+
+  /**
+   * Helper to resolve a location reference to a StrongRef.
+   *
+   * @param location - Location parameter (StrongRef, string URI, or location object)
+   * @returns Promise resolving to a StrongRef
+   * @throws {ValidationError} When string input doesn't match AT-URI pattern
+   * @throws {NetworkError} When getRecord fails or returns no CID
+   * @internal
+   */
+  private async resolveLocation(location: LocationParams): Promise<StrongRef> {
+    if (typeof location === "string") {
+      return this.resolveStrongRefFromUri(location);
+    }
+
+    if (this.isLocationObject(location)) {
+      return this.createLocationRecord(location);
+    }
+
+    if ("uri" in location && "cid" in location) {
+      return { $type: "com.atproto.repo.strongRef" as const, uri: location.uri, cid: location.cid };
+    }
+
+    throw new ValidationError("resolveLocation: Unsupported location input.");
+  }
+
+  private async resolveStrongRefFromUri(uri: string): Promise<StrongRef> {
+    const uriMatch = uri.match(/^at:\/\/([^/]+)\/([^/]+)\/(.+)$/);
+    if (!uriMatch) {
+      throw new ValidationError(`resolveLocation: Invalid location AT-URI: "${uri}"`);
+    }
+
+    const [, repo, collection, rkey] = uriMatch;
+    const record = await this.agent.com.atproto.repo.getRecord({ repo, collection, rkey });
+    if (!record.success) {
+      throw new NetworkError(
+        `resolveLocation: getRecord failed for repo=${repo}, collection=${collection}, rkey=${rkey}`,
+      );
+    }
+    if (!record.data.cid) {
+      throw new NetworkError(
+        `resolveLocation: getRecord returned no CID for repo=${repo}, collection=${collection}, rkey=${rkey}`,
+      );
+    }
+
+    return { $type: "com.atproto.repo.strongRef" as const, uri, cid: record.data.cid };
   }
 
   /**
@@ -1185,7 +1254,7 @@ export class HypercertOperationsImpl extends EventEmitter<HypercertEvents> imple
    *
    * @param params - Collection parameters
    * @param params.title - Collection title
-   * @param params.claims - Array of hypercert references with weights
+   * @param params.items - Array of hypercert references with weights
    * @param params.shortDescription - Optional short description
    * @param params.banner - Optional cover image blob
    * @returns Promise resolving to collection record URI and CID
@@ -1197,80 +1266,76 @@ export class HypercertOperationsImpl extends EventEmitter<HypercertEvents> imple
    * const collection = await repo.hypercerts.createCollection({
    *   title: "Climate Projects 2024",
    *   shortDescription: "Our climate impact portfolio",
-   *   claims: [
-   *     { uri: hypercert1Uri, cid: hypercert1Cid, weight: "0.5" },
-   *     { uri: hypercert2Uri, cid: hypercert2Cid, weight: "0.3" },
-   *     { uri: hypercert3Uri, cid: hypercert3Cid, weight: "0.2" },
+   *   items: [
+   *     { itemIdentifier: { uri: hypercert1Uri, cid: hypercert1Cid }, itemWeight: "0.5" },
+   *     { itemIdentifier: { uri: hypercert2Uri, cid: hypercert2Cid }, itemWeight: "0.3" },
+   *     { itemIdentifier: { uri: hypercert3Uri, cid: hypercert3Cid }, itemWeight: "0.2" },
    *   ],
    *   banner: coverImageBlob,
    * });
    * ```
    */
-  async createCollection(params: {
-    title: string;
-    claims: Array<{ uri: string; cid: string; weight: string }>;
-    shortDescription?: string;
-    banner?: Blob;
-  }): Promise<CreateResult> {
-    try {
-      const createdAt = new Date().toISOString();
+  async createCollection(params: CreateCollectionParams): Promise<CreateCollectionResult> {
+    const createdAt = new Date().toISOString();
 
-      let bannerRef: JsonBlobRef | undefined;
-      if (params.banner) {
-        const arrayBuffer = await params.banner.arrayBuffer();
-        const uint8Array = new Uint8Array(arrayBuffer);
-        const uploadResult = await this.agent.com.atproto.repo.uploadBlob(uint8Array, {
-          encoding: params.banner.type || "image/jpeg",
-        });
-        if (uploadResult.success) {
-          bannerRef = {
-            $type: "blob",
-            ref: { $link: uploadResult.data.blob.ref.toString() },
-            mimeType: uploadResult.data.blob.mimeType,
-            size: uploadResult.data.blob.size,
-          };
-        }
-      }
+    const collectionRecord: HypercertCollection = {
+      $type: HYPERCERT_COLLECTIONS.COLLECTION,
+      title: params.title,
+      items: [],
+      createdAt,
+    };
 
-      const collectionRecord: Record<string, unknown> = {
-        $type: HYPERCERT_COLLECTIONS.COLLECTION,
-        title: params.title,
-        claims: params.claims.map((c) => ({ claim: { uri: c.uri, cid: c.cid }, weight: c.weight })),
-        createdAt,
-      };
-
-      if (params.shortDescription) {
-        collectionRecord.shortDescription = params.shortDescription;
-      }
-
-      if (bannerRef) {
-        collectionRecord.banner = bannerRef;
-      }
-
-      const validation = validate(collectionRecord, HYPERCERT_COLLECTIONS.COLLECTION, "main", false);
-      if (!validation.success) {
-        throw new ValidationError(`Invalid collection record: ${validation.error?.message}`);
-      }
-
-      const result = await this.agent.com.atproto.repo.createRecord({
-        repo: this.repoDid,
-        collection: HYPERCERT_COLLECTIONS.COLLECTION,
-        record: collectionRecord,
-      });
-
-      if (!result.success) {
-        throw new NetworkError("Failed to create collection");
-      }
-
-      this.emit("collectionCreated", { uri: result.data.uri, cid: result.data.cid });
-      return { uri: result.data.uri, cid: result.data.cid };
-    } catch (error) {
-      if (error instanceof ValidationError || error instanceof NetworkError) throw error;
-      throw new NetworkError(
-        `Failed to create collection: ${error instanceof Error ? error.message : "Unknown"}`,
-        error,
-      );
+    if (params.type) {
+      collectionRecord.type = params.type;
     }
+
+    if (params.shortDescription) {
+      collectionRecord.shortDescription = params.shortDescription;
+    }
+
+    if (params.description) {
+      collectionRecord.description = params.description;
+    }
+
+    if (params.avatar) {
+      collectionRecord.avatar = await this.resolveCollectionImageInput(params.avatar);
+    }
+
+    if (params.banner) {
+      collectionRecord.banner = await this.resolveCollectionImageInput(params.banner, true);
+    }
+
+    if (params.items !== undefined) {
+      collectionRecord.items = params.items;
+    }
+
+    if (params.location) {
+      const locationResult = await this.resolveLocation(params.location);
+      collectionRecord.location = locationResult;
+    }
+
+    const validation = validate(collectionRecord, HYPERCERT_COLLECTIONS.COLLECTION, "main", false);
+    if (!validation.success) {
+      throw new ValidationError(`Invalid collection record: ${validation.error?.message}`);
+    }
+
+    const result = await this.agent.com.atproto.repo.createRecord({
+      repo: this.repoDid,
+      collection: HYPERCERT_COLLECTIONS.COLLECTION,
+      record: collectionRecord,
+    });
+
+    if (!result.success) {
+      throw new NetworkError("Failed to create collection");
+    }
+
+    const createCollectionResult: CreateCollectionResult = {
+      uri: result.data.uri,
+      cid: result.data.cid,
+      record: collectionRecord,
+    };
+    this.emit("collectionCreated", createCollectionResult);
+    return createCollectionResult;
   }
 
   /**
@@ -1374,129 +1439,33 @@ export class HypercertOperationsImpl extends EventEmitter<HypercertEvents> imple
   /**
    * Creates a new project that organizes multiple hypercert activities.
    *
-   * Projects are now implemented as collections with `type='project'`.
+   * A project is a collection with type='project' and optional location sidecar.
+   * This method delegates to createCollection and adds the type field.
    *
    * @param params - Project creation parameters
-   * @returns Promise resolving to created project URI and CID
+   * @returns Promise resolving to created project URI and CID with optional location URI
    *
    * @example
    * ```typescript
    * const result = await repo.hypercerts.createProject({
    *   title: "Climate Impact 2024",
    *   shortDescription: "Year-long climate initiative",
-   *   activities: [
-   *     { uri: activity1Uri, cid: activity1Cid, weight: "0.6" },
-   *     { uri: activity2Uri, cid: activity2Cid, weight: "0.4" }
+   *   items: [
+   *     { itemIdentifier: { uri: activity1Uri, cid: activity1Cid }, itemWeight: "0.6" },
+   *     { itemIdentifier: { uri: activity2Uri, cid: activity2Cid }, itemWeight: "0.4" }
    *   ]
    * });
    * console.log(`Created project: ${result.uri}`);
    * ```
    */
-  async createProject(params: {
-    title: string;
-    shortDescription: string;
-    description?: unknown;
-    avatar?: Blob;
-    banner?: Blob;
-    activities?: Array<{ uri: string; cid: string; weight: string }>;
-  }): Promise<CreateResult> {
-    try {
-      const createdAt = new Date().toISOString();
+  async createProject(params: CreateProjectParams): Promise<CreateProjectResult> {
+    const result = await this.createCollection({
+      ...params,
+      type: "project",
+    });
 
-      // Upload avatar blob if provided
-      let avatarRef: JsonBlobRef | undefined;
-      if (params.avatar) {
-        const arrayBuffer = await params.avatar.arrayBuffer();
-        const uint8Array = new Uint8Array(arrayBuffer);
-        const uploadResult = await this.agent.com.atproto.repo.uploadBlob(uint8Array, {
-          encoding: params.avatar.type || "image/jpeg",
-        });
-        if (uploadResult.success) {
-          avatarRef = {
-            $type: "blob",
-            ref: { $link: uploadResult.data.blob.ref.toString() },
-            mimeType: uploadResult.data.blob.mimeType,
-            size: uploadResult.data.blob.size,
-          };
-        } else {
-          throw new NetworkError("Failed to upload avatar image");
-        }
-      }
-
-      // Upload banner blob if provided
-      let bannerRef: JsonBlobRef | undefined;
-      if (params.banner) {
-        const arrayBuffer = await params.banner.arrayBuffer();
-        const uint8Array = new Uint8Array(arrayBuffer);
-        const uploadResult = await this.agent.com.atproto.repo.uploadBlob(uint8Array, {
-          encoding: params.banner.type || "image/jpeg",
-        });
-        if (uploadResult.success) {
-          bannerRef = {
-            $type: "blob",
-            ref: { $link: uploadResult.data.blob.ref.toString() },
-            mimeType: uploadResult.data.blob.mimeType,
-            size: uploadResult.data.blob.size,
-          };
-        } else {
-          throw new NetworkError("Failed to upload banner image");
-        }
-      }
-
-      // Build project record as a collection with type='project'
-      // Collections require 'items' array, so we map activities to items
-      const items =
-        params.activities?.map((a) => ({
-          itemIdentifier: { uri: a.uri, cid: a.cid },
-          itemWeight: a.weight,
-        })) || [];
-
-      const projectRecord: Record<string, unknown> = {
-        $type: HYPERCERT_COLLECTIONS.COLLECTION,
-        type: "project",
-        title: params.title,
-        shortDescription: params.shortDescription,
-        items,
-        createdAt,
-      };
-
-      // Add optional fields
-      if (params.description) {
-        projectRecord.description = params.description;
-      }
-
-      if (avatarRef) {
-        projectRecord.avatar = avatarRef;
-      }
-
-      if (bannerRef) {
-        projectRecord.banner = bannerRef;
-      }
-
-      // Validate against collection lexicon
-      const validation = validate(projectRecord, HYPERCERT_COLLECTIONS.COLLECTION, "main", false);
-      if (!validation.success) {
-        throw new ValidationError(`Invalid project record: ${validation.error?.message}`);
-      }
-
-      // Create record
-      const result = await this.agent.com.atproto.repo.createRecord({
-        repo: this.repoDid,
-        collection: HYPERCERT_COLLECTIONS.COLLECTION,
-        record: projectRecord,
-      });
-
-      if (!result.success) {
-        throw new NetworkError("Failed to create project");
-      }
-
-      // Emit event
-      this.emit("projectCreated", { uri: result.data.uri, cid: result.data.cid });
-      return { uri: result.data.uri, cid: result.data.cid };
-    } catch (error) {
-      if (error instanceof ValidationError || error instanceof NetworkError) throw error;
-      throw new NetworkError(`Failed to create project: ${error instanceof Error ? error.message : "Unknown"}`, error);
-    }
+    this.emit("projectCreated", { uri: result.uri, cid: result.cid });
+    return result;
   }
 
   /**
@@ -1619,7 +1588,8 @@ export class HypercertOperationsImpl extends EventEmitter<HypercertEvents> imple
   /**
    * Updates an existing project.
    *
-   * Projects are collections with `type='project'`.
+   * A project is a collection with type='project'. This method delegates to
+   * updateCollection and handles the avatar field.
    *
    * @param uri - AT-URI of the project to update
    * @param updates - Fields to update
@@ -1633,19 +1603,85 @@ export class HypercertOperationsImpl extends EventEmitter<HypercertEvents> imple
    * });
    * ```
    */
-  async updateProject(
-    uri: string,
-    updates: {
-      title?: string;
-      shortDescription?: string;
-      description?: unknown;
-      avatar?: Blob | null;
-      banner?: Blob | null;
-      activities?: Array<{ uri: string; cid: string; weight: string }>;
-    },
-  ): Promise<UpdateResult> {
+  async updateProject(uri: string, updates: UpdateProjectParams): Promise<UpdateResult> {
+    // Verify it's a project before updating
+    const uriMatch = uri.match(/^at:\/\/([^/]+)\/([^/]+)\/(.+)$/);
+    if (!uriMatch) {
+      throw new ValidationError(`Invalid URI format: ${uri}`);
+    }
+    const [, , collection, rkey] = uriMatch;
+
+    const existing = await this.agent.com.atproto.repo.getRecord({
+      repo: this.repoDid,
+      collection,
+      rkey,
+    });
+
+    if (!existing.success) {
+      throw new NetworkError(`Project not found: ${uri}`);
+    }
+
+    const record = existing.data.value as HypercertCollection;
+    if (record.type !== "project") {
+      throw new ValidationError(`Record is not a project (type='${record.type}')`);
+    }
+
+    // Delegate to updateCollection
+    const result = await this.updateCollection(uri, updates);
+
+    this.emit("projectUpdated", { uri: result.uri, cid: result.cid });
+    return result;
+  }
+
+  /**
+   * Deletes a project.
+   *
+   * A project is a collection with type='project'. This method delegates to
+   * deleteCollection after verifying the record is a project.
+   *
+   * @param uri - AT-URI of the project to delete
+   *
+   * @example
+   * ```typescript
+   * await repo.hypercerts.deleteProject(projectUri);
+   * console.log("Project deleted");
+   * ```
+   */
+  async deleteProject(uri: string): Promise<void> {
+    const uriMatch = uri.match(/^at:\/\/([^/]+)\/([^/]+)\/(.+)$/);
+    if (!uriMatch) {
+      throw new ValidationError(`Invalid URI format: ${uri}`);
+    }
+    const [, , collection, rkey] = uriMatch;
+
+    const existing = await this.agent.com.atproto.repo.getRecord({
+      repo: this.repoDid,
+      collection,
+      rkey,
+    });
+
+    if (!existing.success) {
+      throw new NetworkError(`Project not found: ${uri}`);
+    }
+
+    const record = existing.data.value as HypercertCollection;
+    if (record.type !== "project") {
+      throw new ValidationError(`Record is not a project (type='${record.type}')`);
+    }
+
+    await this.deleteCollection(uri);
+    this.emit("projectDeleted", { uri });
+  }
+
+  /**
+   * Updates a collection.
+   *
+   * @param uri - AT-URI of the collection to update
+   * @param updates - Fields to update
+   * @returns Promise resolving to updated collection URI and CID
+   */
+  async updateCollection(uri: string, updates: UpdateCollectionParams): Promise<UpdateResult> {
     try {
-      // Parse URI and fetch existing record
       const uriMatch = uri.match(/^at:\/\/([^/]+)\/([^/]+)\/(.+)$/);
       if (!uriMatch) {
         throw new ValidationError(`Invalid URI format: ${uri}`);
@@ -1659,99 +1695,74 @@ export class HypercertOperationsImpl extends EventEmitter<HypercertEvents> imple
       });
 
       if (!existing.success) {
-        throw new NetworkError(`Project not found: ${uri}`);
+        throw new NetworkError(`Collection not found: ${uri}`);
       }
 
       const existingRecord = existing.data.value as HypercertCollection;
 
-      // Verify it's actually a project
-      if (existingRecord.type !== "project") {
-        throw new ValidationError(`Record is not a project (type='${existingRecord.type}')`);
-      }
-
-      // Merge updates with existing record
       const recordForUpdate: Record<string, unknown> = {
         ...existingRecord,
-        // MUST preserve type, createdAt, and items structure
-        type: "project",
         createdAt: existingRecord.createdAt,
+        type: existingRecord.type,
       };
 
-      // Apply simple field updates
       if (updates.title !== undefined) recordForUpdate.title = updates.title;
       if (updates.shortDescription !== undefined) recordForUpdate.shortDescription = updates.shortDescription;
       if (updates.description !== undefined) recordForUpdate.description = updates.description;
 
-      // Handle avatar update with three-way logic
+      // Explicitly reject type changes
+      if (updates.type !== undefined && updates.type !== existingRecord.type) {
+        throw new ValidationError(`Cannot change collection type from '${existingRecord.type}' to '${updates.type}'`);
+      }
+
       delete (recordForUpdate as { avatar?: unknown }).avatar;
       if (updates.avatar !== undefined) {
         if (updates.avatar === null) {
           // Remove avatar
         } else {
-          const arrayBuffer = await updates.avatar.arrayBuffer();
-          const uint8Array = new Uint8Array(arrayBuffer);
-          const uploadResult = await this.agent.com.atproto.repo.uploadBlob(uint8Array, {
-            encoding: updates.avatar.type || "image/jpeg",
-          });
-          if (uploadResult.success) {
-            recordForUpdate.avatar = {
-              $type: "blob",
-              ref: uploadResult.data.blob.ref,
-              mimeType: uploadResult.data.blob.mimeType,
-              size: uploadResult.data.blob.size,
-            };
-          } else {
-            throw new NetworkError("Failed to upload avatar image");
-          }
+          recordForUpdate.avatar = await this.resolveCollectionImageInput(updates.avatar);
         }
       } else if (existingRecord.avatar) {
         recordForUpdate.avatar = existingRecord.avatar;
       }
 
-      // Handle banner update
       delete (recordForUpdate as { banner?: unknown }).banner;
       if (updates.banner !== undefined) {
         if (updates.banner === null) {
           // Remove banner
         } else {
-          const arrayBuffer = await updates.banner.arrayBuffer();
-          const uint8Array = new Uint8Array(arrayBuffer);
-          const uploadResult = await this.agent.com.atproto.repo.uploadBlob(uint8Array, {
-            encoding: updates.banner.type || "image/jpeg",
-          });
-          if (uploadResult.success) {
-            recordForUpdate.banner = {
-              $type: "blob",
-              ref: uploadResult.data.blob.ref,
-              mimeType: uploadResult.data.blob.mimeType,
-              size: uploadResult.data.blob.size,
-            };
-          } else {
-            throw new NetworkError("Failed to upload banner image");
-          }
+          recordForUpdate.banner = await this.resolveCollectionImageInput(updates.banner, true);
         }
       } else if (existingRecord.banner) {
         recordForUpdate.banner = existingRecord.banner;
       }
 
-      // Transform activities to items array
-      if (updates.activities) {
-        recordForUpdate.items = updates.activities.map((a) => ({
-          itemIdentifier: { uri: a.uri, cid: a.cid },
-          itemWeight: a.weight,
-        }));
-      } else {
-        // Preserve existing items
+      delete (recordForUpdate as { location?: unknown }).location;
+      if (updates.location !== undefined) {
+        if (updates.location === null) {
+          // Remove location
+        } else {
+          const resolvedLocation = await this.resolveLocation(updates.location);
+          if (!resolvedLocation) {
+            throw new ValidationError("resolveLocation: failed to resolve location");
+          }
+          recordForUpdate.location = resolvedLocation;
+        }
+      } else if (existingRecord.location) {
+        recordForUpdate.location = existingRecord.location;
+      }
+
+      if (updates.items) {
+        recordForUpdate.items = updates.items;
+      } else if (existingRecord.items) {
         recordForUpdate.items = existingRecord.items;
       }
 
-      // Validate merged record
       const validation = validate(recordForUpdate, HYPERCERT_COLLECTIONS.COLLECTION, "main", false);
       if (!validation.success) {
-        throw new ValidationError(`Invalid project record: ${validation.error?.message}`);
+        throw new ValidationError(`Invalid collection record: ${validation.error?.message}`);
       }
 
-      // Update record
       const result = await this.agent.com.atproto.repo.putRecord({
         repo: this.repoDid,
         collection,
@@ -1760,55 +1771,33 @@ export class HypercertOperationsImpl extends EventEmitter<HypercertEvents> imple
       });
 
       if (!result.success) {
-        throw new NetworkError("Failed to update project");
+        throw new NetworkError("Failed to update collection");
       }
 
-      // Emit event
-      this.emit("projectUpdated", { uri: result.data.uri, cid: result.data.cid });
+      this.emit("collectionUpdated", { uri: result.data.uri, cid: result.data.cid });
       return { uri: result.data.uri, cid: result.data.cid };
     } catch (error) {
       if (error instanceof ValidationError || error instanceof NetworkError) throw error;
-      throw new NetworkError(`Failed to update project: ${error instanceof Error ? error.message : "Unknown"}`, error);
+      throw new NetworkError(
+        `Failed to update collection: ${error instanceof Error ? error.message : "Unknown"}`,
+        error,
+      );
     }
   }
 
   /**
-   * Deletes a project.
+   * Deletes a collection.
    *
-   * Projects are collections with `type='project'`.
-   *
-   * @param uri - AT-URI of the project to delete
-   *
-   * @example
-   * ```typescript
-   * await repo.hypercerts.deleteProject(projectUri);
-   * console.log("Project deleted");
-   * ```
+   * @param uri - AT-URI of the collection to delete
    */
-  async deleteProject(uri: string): Promise<void> {
+  async deleteCollection(uri: string): Promise<void> {
     try {
-      // Parse URI
       const uriMatch = uri.match(/^at:\/\/([^/]+)\/([^/]+)\/(.+)$/);
       if (!uriMatch) {
         throw new ValidationError(`Invalid URI format: ${uri}`);
       }
       const [, , collection, rkey] = uriMatch;
 
-      // Verify it's actually a project before deleting
-      const existing = await this.agent.com.atproto.repo.getRecord({
-        repo: this.repoDid,
-        collection,
-        rkey,
-      });
-
-      if (existing.success) {
-        const record = existing.data.value as HypercertCollection;
-        if (record.type !== "project") {
-          throw new ValidationError(`Record is not a project (type='${record.type}')`);
-        }
-      }
-
-      // Delete record
       const result = await this.agent.com.atproto.repo.deleteRecord({
         repo: this.repoDid,
         collection,
@@ -1816,14 +1805,190 @@ export class HypercertOperationsImpl extends EventEmitter<HypercertEvents> imple
       });
 
       if (!result.success) {
-        throw new NetworkError("Failed to delete project");
+        throw new NetworkError("Failed to delete collection");
       }
 
-      // Emit event
-      this.emit("projectDeleted", { uri });
+      this.emit("collectionDeleted", { uri });
     } catch (error) {
       if (error instanceof ValidationError || error instanceof NetworkError) throw error;
-      throw new NetworkError(`Failed to delete project: ${error instanceof Error ? error.message : "Unknown"}`, error);
+      throw new NetworkError(
+        `Failed to delete collection: ${error instanceof Error ? error.message : "Unknown"}`,
+        error,
+      );
     }
+  }
+
+  /**
+   * Attaches a location to a collection.
+   *
+   * @param uri - AT-URI of the collection
+   * @param location - Location data
+   * @returns Promise resolving to location record result
+   */
+  async attachLocationToCollection(uri: string, location: LocationParams): Promise<CreateResult> {
+    try {
+      const uriMatch = uri.match(/^at:\/\/([^/]+)\/([^/]+)\/(.+)$/);
+      if (!uriMatch) {
+        throw new ValidationError(`Invalid URI format: ${uri}`);
+      }
+      const [, , collection, rkey] = uriMatch;
+
+      const existing = await this.agent.com.atproto.repo.getRecord({
+        repo: this.repoDid,
+        collection,
+        rkey,
+      });
+
+      if (!existing.success) {
+        throw new NetworkError(`Collection not found: ${uri}`);
+      }
+
+      const resolvedLocation = await this.resolveLocation(location);
+      if (!resolvedLocation) {
+        throw new ValidationError("attachLocationToCollection: failed to resolve location");
+      }
+
+      const recordForUpdate: Record<string, unknown> = {
+        ...existing.data.value,
+        location: resolvedLocation,
+      };
+
+      const updateResult = await this.agent.com.atproto.repo.putRecord({
+        repo: this.repoDid,
+        collection,
+        rkey,
+        record: recordForUpdate,
+      });
+
+      if (!updateResult.success) {
+        throw new NetworkError("Failed to update collection with location");
+      }
+
+      this.emit("locationAttachedToCollection", {
+        uri: resolvedLocation.uri,
+        cid: resolvedLocation.cid,
+        collectionUri: uri,
+      });
+      return { uri: resolvedLocation.uri, cid: resolvedLocation.cid };
+    } catch (error) {
+      if (error instanceof ValidationError || error instanceof NetworkError) throw error;
+      throw new NetworkError(`Failed to attach location: ${error instanceof Error ? error.message : "Unknown"}`, error);
+    }
+  }
+
+  /**
+   * Removes a location from a collection.
+   *
+   * @param uri - AT-URI of the collection
+   */
+  async removeLocationFromCollection(uri: string): Promise<void> {
+    try {
+      const uriMatch = uri.match(/^at:\/\/([^/]+)\/([^/]+)\/(.+)$/);
+      if (!uriMatch) {
+        throw new ValidationError(`Invalid URI format: ${uri}`);
+      }
+      const [, , collection, rkey] = uriMatch;
+
+      const existing = await this.agent.com.atproto.repo.getRecord({
+        repo: this.repoDid,
+        collection,
+        rkey,
+      });
+
+      if (!existing.success) {
+        throw new NetworkError(`Collection not found: ${uri}`);
+      }
+
+      const recordForUpdate = { ...existing.data.value };
+      delete (recordForUpdate as { location?: unknown }).location;
+
+      const result = await this.agent.com.atproto.repo.putRecord({
+        repo: this.repoDid,
+        collection,
+        rkey,
+        record: recordForUpdate,
+      });
+
+      if (!result.success) {
+        throw new NetworkError("Failed to remove location from collection");
+      }
+
+      this.emit("locationRemovedFromCollection", { collectionUri: uri });
+    } catch (error) {
+      if (error instanceof ValidationError || error instanceof NetworkError) throw error;
+      throw new NetworkError(`Failed to remove location: ${error instanceof Error ? error.message : "Unknown"}`, error);
+    }
+  }
+
+  /**
+   * Attaches a location to a project.
+   *
+   * @param uri - AT-URI of the project
+   * @param location - Location data
+   * @returns Promise resolving to location record result
+   */
+  async attachLocationToProject(uri: string, location: LocationParams): Promise<CreateResult> {
+    const result = await this.attachLocationToCollection(uri, location);
+    this.emit("locationAttachedToProject", {
+      uri: result.uri,
+      cid: result.cid,
+      projectUri: uri,
+    });
+    return result;
+  }
+
+  /**
+   * Removes a location from a project.
+   *
+   * @param uri - AT-URI of the project
+   */
+  async removeLocationFromProject(uri: string): Promise<void> {
+    await this.removeLocationFromCollection(uri);
+    this.emit("locationRemovedFromProject", { projectUri: uri });
+  }
+
+  /**
+   * Creates an app.certified.location record.
+   *
+   * @param location - Location parameters
+   * @returns Promise resolving to location record URI and CID
+   */
+  private async createLocationRecord(location: CreateLocationParams): Promise<StrongRef> {
+    if (!location.srs) {
+      throw new ValidationError(
+        "srs (Spatial Reference System) is required. Example: 'EPSG:4326' for WGS84 coordinates, or 'http://www.opengis.net/def/crs/OGC/1.3/CRS84' for CRS84.",
+      );
+    }
+
+    const { $type, createdAt, location: locationValue, lpVersion, ...rest } = location;
+    if (locationValue === undefined) {
+      throw new ValidationError("location is required to create a location record.");
+    }
+    const resolvedLocationValue = await this.resolveLocationValue(locationValue);
+
+    const locationRecord: HypercertLocation = {
+      ...rest,
+      lpVersion: lpVersion ?? "1.0",
+      $type: $type ?? HYPERCERT_COLLECTIONS.LOCATION,
+      createdAt: createdAt ?? new Date().toISOString(),
+      location: resolvedLocationValue,
+    };
+
+    const validation = validate(locationRecord, HYPERCERT_COLLECTIONS.LOCATION, "main", false);
+    if (!validation.success) {
+      throw new ValidationError(`Invalid location record: ${validation.error?.message}`);
+    }
+
+    const result = await this.agent.com.atproto.repo.createRecord({
+      repo: this.repoDid,
+      collection: HYPERCERT_COLLECTIONS.LOCATION,
+      record: locationRecord as Record<string, unknown>,
+    });
+
+    if (!result.success) {
+      throw new NetworkError("Failed to create location record");
+    }
+
+    return { uri: result.data.uri, cid: result.data.cid };
   }
 }

--- a/packages/sdk-core/src/repository/interfaces.ts
+++ b/packages/sdk-core/src/repository/interfaces.ts
@@ -9,7 +9,18 @@
  */
 
 import type { EventEmitter } from "eventemitter3";
-import type { HypercertCollection, HypercertClaim, OrgHypercertsDefs } from "../services/hypercerts/types.js";
+import type {
+  LocationParams,
+  CreateCollectionParams,
+  CreateCollectionResult,
+  CreateProjectParams,
+  CreateProjectResult,
+  HypercertCollection,
+  HypercertClaim,
+  OrgHypercertsDefs,
+  UpdateCollectionParams,
+  UpdateProjectParams,
+} from "../services/hypercerts/types.js";
 import type {
   CreateResult,
   ListParams,
@@ -20,6 +31,9 @@ import type {
   RepositoryRole,
   UpdateResult,
 } from "./types.js";
+
+// Re-export AttachLocationParams for convenience
+export type { LocationParams };
 
 // ============================================================================
 // Hypercert Operation Types
@@ -176,7 +190,7 @@ export interface CreateHypercertParams {
   /**
    * Optional geographic location of the impact.
    */
-  location?: AttachLocationParams;
+  location?: LocationParams;
 
   /**
    * Optional list of contributions to the impact.
@@ -276,50 +290,6 @@ export interface CreateHypercertEvidenceParams {
    * Any additional custom fields supported by the record.
    */
   [k: string]: unknown;
-}
-
-/**
- * Parameters for attaching a location to a hypercert.
- *
- * @example Using a string location
- * ```typescript
- * const params: AttachLocationParams = {
- *   lpVersion: "1.0.0",
- *   srs: "EPSG:4326",
- *   locationType: "coordinate-decimal",
- *   location: "https://locationuri.com",
- *   name: "San Francisco",
- *   description: "Project location in SF Bay Area",
- * };
- * ```
- *
- * @example Using a GeoJSON Blob
- * ```typescript
- * const geojsonBlob = new Blob(
- *   [JSON.stringify({ type: "Point", coordinates: [-122.4194, 37.7749] })],
- *   { type: "application/geo+json" }
- * );
- * const params: AttachLocationParams = {
- *   lpVersion: "1.0.0",
- *   srs: "EPSG:4326",
- *   locationType: "geojson-point",
- *   location: geojsonBlob,
- * };
- * ```
- */
-export interface AttachLocationParams {
-  /** The version of the Location Protocol */
-  lpVersion: string;
-  /** The Spatial Reference System URI (e.g., http://www.opengis.net/def/crs/OGC/1.3/CRS84) that defines the coordinate system. */
-  srs: string;
-  /** An identifier for the format of the location data (e.g., coordinate-decimal, geojson-point) */
-  locationType: "coordinate-decimal" | "geojson-point" | (string & {});
-  /** Location data as either a URL string or a GeoJSON Blob */
-  location: string | Blob;
-  /** Optional name for this location */
-  name?: string;
-  /** Optional description for this location */
-  description?: string;
 }
 
 /**
@@ -660,6 +630,26 @@ export interface HypercertEvents {
   collectionCreated: { uri: string; cid: string };
 
   /**
+   * Emitted when a collection is updated.
+   */
+  collectionUpdated: { uri: string; cid: string };
+
+  /**
+   * Emitted when a collection is deleted.
+   */
+  collectionDeleted: { uri: string };
+
+  /**
+   * Emitted when a location is attached to a collection.
+   */
+  locationAttachedToCollection: { uri: string; cid: string; collectionUri: string };
+
+  /**
+   * Emitted when a location is removed from a collection.
+   */
+  locationRemovedFromCollection: { collectionUri: string };
+
+  /**
    * Emitted when a project is created.
    */
   projectCreated: { uri: string; cid: string };
@@ -673,6 +663,16 @@ export interface HypercertEvents {
    * Emitted when a project is deleted.
    */
   projectDeleted: { uri: string };
+
+  /**
+   * Emitted when a location is attached to a project.
+   */
+  locationAttachedToProject: { uri: string; cid: string; projectUri: string };
+
+  /**
+   * Emitted when a location is removed from a project.
+   */
+  locationRemovedFromProject: { projectUri: string };
 }
 
 /**
@@ -728,11 +728,7 @@ export interface HypercertOperations extends EventEmitter<HypercertEvents> {
    * @param params.image - New image, or `null` to remove
    * @returns Promise resolving to update result
    */
-  update(params: {
-    uri: string;
-    updates: Partial<Omit<HypercertClaim, "$type" | "createdAt" | "rights">>;
-    image?: Blob | null;
-  }): Promise<UpdateResult>;
+  update(params: { uri: string; updates: Partial<CreateHypercertParams>; image?: Blob | null }): Promise<UpdateResult>;
 
   /**
    * Gets a hypercert by URI.
@@ -772,7 +768,7 @@ export interface HypercertOperations extends EventEmitter<HypercertEvents> {
    * @param location.geojson - Optional GeoJSON blob for precise boundaries
    * @returns Promise resolving to location record result
    */
-  attachLocation(uri: string, location: AttachLocationParams): Promise<CreateResult>;
+  attachLocation(uri: string, location: LocationParams): Promise<CreateResult>;
 
   /**
    * Adds evidence to an existing hypercert.
@@ -822,14 +818,9 @@ export interface HypercertOperations extends EventEmitter<HypercertEvents> {
    * Creates a collection of hypercerts.
    *
    * @param params - Collection parameters
-   * @returns Promise resolving to collection record result
+   * @returns Promise resolving to collection record result with optional location URI
    */
-  createCollection(params: {
-    title: string;
-    claims: Array<{ uri: string; cid: string; weight: string }>;
-    shortDescription?: string;
-    banner?: Blob;
-  }): Promise<CreateResult>;
+  createCollection(params: CreateCollectionParams): Promise<CreateCollectionResult>;
 
   /**
    * Gets a collection by URI.
@@ -850,19 +841,48 @@ export interface HypercertOperations extends EventEmitter<HypercertEvents> {
   ): Promise<PaginatedList<{ uri: string; cid: string; record: HypercertCollection }>>;
 
   /**
+   * Updates a collection.
+   *
+   * @param uri - AT-URI of the collection
+   * @param updates - Fields to update
+   * @returns Promise resolving to update result
+   */
+  updateCollection(uri: string, updates: UpdateCollectionParams): Promise<UpdateResult>;
+
+  /**
+   * Deletes a collection.
+   *
+   * @param uri - AT-URI of the collection
+   * @returns Promise resolving when deleted
+   */
+  deleteCollection(uri: string): Promise<void>;
+
+  /**
+   * Attaches a location to a collection.
+   *
+   * @param uri - AT-URI of the collection
+   * @param location - Location data
+   * @returns Promise resolving to location record result
+   */
+  attachLocationToCollection(uri: string, location: LocationParams): Promise<CreateResult>;
+
+  /**
+   * Removes a location from a collection.
+   *
+   * @param uri - AT-URI of the collection
+   * @returns Promise resolving when location is removed
+   */
+  removeLocationFromCollection(uri: string): Promise<void>;
+
+  /**
    * Creates a project.
    *
+   * A project is a collection with type='project' and optional location sidecar.
+   *
    * @param params - Project parameters
-   * @returns Promise resolving to project record result
+   * @returns Promise resolving to project record result with optional location URI
    */
-  createProject(params: {
-    title: string;
-    shortDescription: string;
-    description?: unknown;
-    avatar?: Blob;
-    banner?: Blob;
-    activities?: Array<{ uri: string; cid: string; weight: string }>;
-  }): Promise<CreateResult>;
+  createProject(params: CreateProjectParams): Promise<CreateProjectResult>;
 
   /**
    * Gets a project by URI.
@@ -891,17 +911,7 @@ export interface HypercertOperations extends EventEmitter<HypercertEvents> {
    * @param updates - Fields to update
    * @returns Promise resolving to update result
    */
-  updateProject(
-    uri: string,
-    updates: {
-      title?: string;
-      shortDescription?: string;
-      description?: unknown;
-      avatar?: Blob | null;
-      banner?: Blob | null;
-      activities?: Array<{ uri: string; cid: string; weight: string }>;
-    },
-  ): Promise<UpdateResult>;
+  updateProject(uri: string, updates: UpdateProjectParams): Promise<UpdateResult>;
 
   /**
    * Deletes a project.
@@ -910,6 +920,23 @@ export interface HypercertOperations extends EventEmitter<HypercertEvents> {
    * @returns Promise resolving when deleted
    */
   deleteProject(uri: string): Promise<void>;
+
+  /**
+   * Attaches a location to a project.
+   *
+   * @param uri - AT-URI of the project
+   * @param location - Location data
+   * @returns Promise resolving to location record result
+   */
+  attachLocationToProject(uri: string, location: LocationParams): Promise<CreateResult>;
+
+  /**
+   * Removes a location from a project.
+   *
+   * @param uri - AT-URI of the project
+   * @returns Promise resolving when location is removed
+   */
+  removeLocationFromProject(uri: string): Promise<void>;
 }
 
 /**

--- a/packages/sdk-core/src/services/hypercerts/types.ts
+++ b/packages/sdk-core/src/services/hypercerts/types.ts
@@ -9,6 +9,7 @@
 // Re-export BlobRef from ATProto lexicon
 export { BlobRef } from "@atproto/lexicon";
 export type { JsonBlobRef } from "@atproto/lexicon";
+import type { OverrideProperties, SetOptional } from "type-fest";
 
 // Re-export everything from lexicon package
 export {
@@ -105,68 +106,137 @@ export type FundingReceipt = OrgHypercertsFundingReceipt.Main;
 /**
  * Image input for SDK operations.
  *
- * Can be either:
- * - A URI reference (for external images)
- * - A Blob to be uploaded
+ * Accepts either:
+ * - A string URI reference (for external images)
+ * - A Blob to be uploaded (will be converted to SmallImage or LargeImage)
  *
- * The SDK will convert these to the appropriate lexicon types:
- * - OrgHypercertsDefs.Uri
- * - OrgHypercertsDefs.SmallImage
- * - OrgHypercertsDefs.LargeImage
+ * The SDK will convert these inputs to the appropriate lexicon types.
  */
-export type HypercertImage = { type: "uri"; uri: string } | { type: "blob"; blob: Blob };
+export type HypercertImage = string | Blob;
 
 /**
  * Lexicon-defined image types (union of Uri and image blob types).
- * Use this when working with stored records.
+ *
+ * Used when working with stored records. Can be:
+ * - OrgHypercertsDefs.Uri - External image reference
+ * - OrgHypercertsDefs.SmallImage - Uploaded blob for avatars/thumbnails
+ * - OrgHypercertsDefs.LargeImage - Uploaded blob for banners/covers
  */
 export type HypercertImageRecord = OrgHypercertsDefs.Uri | OrgHypercertsDefs.SmallImage | OrgHypercertsDefs.LargeImage;
+/** Hypercert with resolved metadata */
+export type HypercertWithMetadata = HypercertClaim & {
+  resolvedRights?: HypercertRights;
+  resolvedLocation?: HypercertLocation;
+};
 
-/** Hypercert with AT Protocol metadata */
-export interface HypercertWithMetadata {
+/** Project type alias (collection with type="project") */
+export type HypercertProject = HypercertCollection & { type: "project" };
+
+/** Project with resolved metadata */
+export type HypercertProjectWithMetadata = HypercertCollection & {
+  resolvedLocation?: HypercertLocation;
+  resolvedActivities?: HypercertClaim[];
+};
+
+export type { OrgHypercertsClaimCollection as CollectionLexicon } from "@hypercerts-org/lexicon";
+
+// ============================================================================
+// SDK Input Helper Types (Derived from Lexicon)
+// ============================================================================
+
+export type CollectionItemInput = SetOptional<OrgHypercertsClaimCollection.Item, "$type">;
+
+/**
+ * Parameters for specifying a location in collection/project operations.
+ * Supports three ways to specify location:
+ *
+ * 1. **StrongRef** - Direct reference with uri and cid (no record creation)
+ * 2. **AT-URI string** - Reference to existing location record
+ * 3. **Location object** - Full location data (lpVersion, srs, locationType, location, etc.)
+ *    with optional `$type` and `createdAt` fields
+ *    where-as location field can be a Blob (e.g., GeoJSON) that will be uploaded
+ *
+ * @example Using a StrongRef (no record creation)
+ * ```typescript
+ * const location: AttachLocationParams = { uri: "at://did:plc:test/app.certified.location/abc", cid: "bafyrei..." };
+ * ```
+ *
+ * @example Using an AT-URI (fetches existing record)
+ * ```typescript
+ * const location: AttachLocationParams = "at://did:plc:test/app.certified.location/xyz";
+ * ```
+ *
+ * @example Using a location object
+ * ```typescript
+ * const location: AttachLocationParams = {
+ *   lpVersion: "1.0.0",
+ *   srs: "EPSG:4326",
+ *   locationType: "coordinate-decimal",
+ *   location: "https://locationuri.com",
+ *   name: "San Francisco",
+ * };
+ * ```
+ */
+
+export type CreateLocationParams = OverrideProperties<
+  SetOptional<HypercertLocation, "$type" | "createdAt">,
+  {
+    location: string | Blob | HypercertLocation["location"];
+  }
+>;
+
+export type LocationParams = StrongRef | string | CreateLocationParams;
+
+/**
+ * SDK input parameters for creating a collection.
+ * Derived from lexicon type with $type and createdAt removed.
+ * avatar/banner accept HypercertImage (string URI or Blob) for user convenience.
+ * Location can be provided inline or via attachLocationToCollection().
+ */
+export type CreateCollectionParams = OverrideProperties<
+  SetOptional<OrgHypercertsClaimCollection.Main, "$type" | "createdAt">,
+  {
+    avatar?: HypercertImage;
+    banner?: HypercertImage;
+    items: CollectionItemInput[];
+    /**
+     * Optional location to attach to the collection.
+     * Can be:
+     * - StrongRef to reference existing location (uri + cid)
+     * - string (AT-URI) to reference existing location (CID will be fetched)
+     * - Location object to create a new location record
+     */
+    location?: LocationParams;
+  }
+>;
+
+/**
+ * SDK input parameters for updating a collection.
+ * All fields are optional.
+ * avatar/banner accept HypercertImage (string URI or Blob), or null to remove.
+ * Location can be updated inline or removed with null.
+ */
+export type UpdateCollectionParams = Omit<Partial<CreateCollectionParams>, "avatar" | "banner" | "location"> & {
+  avatar?: HypercertImage | null;
+  banner?: HypercertImage | null;
+  location?: LocationParams | null;
+};
+
+export type CreateCollectionResult = {
   uri: string;
   cid: string;
-  record: HypercertClaim;
-}
+  record: HypercertCollection;
+};
 
 /**
- * Project type - a HypercertCollection with type='project'.
+ * SDK input parameters for creating a project.
+ * Projects are collections with type="project" (set automatically).
  */
-export interface HypercertProject extends HypercertCollection {
-  type: "project";
-}
+export type CreateProjectParams = CreateCollectionParams;
 
 /**
- * HypercertProject with AT Protocol metadata.
+ * SDK input parameters for updating a project.
  */
-export interface HypercertProjectWithMetadata {
-  uri: string;
-  cid: string;
-  record: HypercertProject;
-}
+export type UpdateProjectParams = UpdateCollectionParams;
 
-/**
- * Parameters for creating a project.
- */
-export interface CreateProjectParams {
-  title: string;
-  shortDescription: string;
-  description?: unknown;
-  avatar?: Blob;
-  banner?: Blob;
-  activities?: Array<{ uri: string; cid: string; weight: string }>;
-  location?: { uri: string; cid: string };
-}
-
-/**
- * Parameters for updating a project.
- */
-export interface UpdateProjectParams {
-  title?: string;
-  shortDescription?: string;
-  description?: unknown;
-  avatar?: Blob;
-  banner?: Blob;
-  activities?: Array<{ uri: string; cid: string; weight: string }>;
-  location?: { uri: string; cid: string };
-}
+export type CreateProjectResult = CreateCollectionResult;

--- a/packages/sdk-core/tests/repository/HypercertOperationsImpl.test.ts
+++ b/packages/sdk-core/tests/repository/HypercertOperationsImpl.test.ts
@@ -810,7 +810,7 @@ describe("HypercertOperationsImpl", () => {
 
       const result = await hypercertOps.createCollection({
         title: "My Collection",
-        claims: [{ uri: "at://claim1", cid: "cid1", weight: "50" }],
+        items: [{ itemIdentifier: { uri: "at://claim1", cid: "cid1" }, itemWeight: "50" }],
       });
 
       expect(result.uri).toContain("collection");
@@ -827,10 +827,127 @@ describe("HypercertOperationsImpl", () => {
 
       await hypercertOps.createCollection({
         title: "Collection",
-        claims: [],
+        items: [],
       });
 
       expect(handler).toHaveBeenCalled();
+    });
+
+    it("should throw ValidationError for invalid collection data", async () => {
+      const { validate } = await import("@hypercerts-org/lexicon");
+      const mockValidate = validate as ReturnType<typeof vi.fn>;
+
+      // Mock validation failure
+      mockValidate.mockReturnValue({
+        success: false,
+        error: { message: "Missing required field: title" },
+      });
+
+      await expect(
+        hypercertOps.createCollection({
+          title: "", // Invalid: empty title
+          items: [],
+        }),
+      ).rejects.toThrow(ValidationError);
+
+      await expect(
+        hypercertOps.createCollection({
+          title: "",
+          items: [],
+        }),
+      ).rejects.toThrow("Invalid collection record");
+
+      // Reset mock to default success behavior for other tests
+      mockValidate.mockReturnValue({ success: true });
+    });
+
+    it("should create a collection with inline location (StrongRef)", async () => {
+      mockAgent.com.atproto.repo.createRecord.mockResolvedValue({
+        success: true,
+        data: { uri: "at://did:plc:test/org.hypercerts.collection/xyz", cid: "collection-cid" },
+      });
+
+      const result = await hypercertOps.createCollection({
+        title: "My Collection",
+        items: [],
+        location: { uri: "at://did:plc:test/app.certified.location/loc123", cid: "location-cid" },
+      });
+
+      expect(result.uri).toContain("collection");
+      expect(result.record.location?.uri).toEqual("at://did:plc:test/app.certified.location/loc123");
+      expect(mockAgent.com.atproto.repo.createRecord).toHaveBeenCalledWith(
+        expect.objectContaining({
+          record: expect.objectContaining({
+            location: expect.objectContaining({
+              uri: "at://did:plc:test/app.certified.location/loc123",
+              cid: "location-cid",
+            }),
+          }),
+        }),
+      );
+    });
+
+    it("should create a collection with inline location (AT-URI string)", async () => {
+      mockAgent.com.atproto.repo.getRecord.mockResolvedValue({
+        success: true,
+        data: {
+          uri: "at://did:plc:test/app.certified.location/existing",
+          cid: "existing-location-cid",
+        },
+      });
+      mockAgent.com.atproto.repo.createRecord.mockResolvedValue({
+        success: true,
+        data: { uri: "at://did:plc:test/org.hypercerts.collection/xyz", cid: "collection-cid" },
+      });
+
+      const result = await hypercertOps.createCollection({
+        title: "My Collection",
+        items: [],
+        location: "at://did:plc:test/app.certified.location/existing",
+      });
+
+      expect(result.uri).toContain("collection");
+      expect(result.record.location?.uri).toBe("at://did:plc:test/app.certified.location/existing");
+      // Should have fetched the location to get CID
+      expect(mockAgent.com.atproto.repo.getRecord).toHaveBeenCalledWith(
+        expect.objectContaining({
+          collection: "app.certified.location",
+          rkey: "existing",
+        }),
+      );
+    });
+
+    it("should create a collection with inline location (location object)", async () => {
+      // Mock createRecord for location
+      mockAgent.com.atproto.repo.createRecord.mockResolvedValueOnce({
+        success: true,
+        data: { uri: "at://did:plc:test/app.certified.location/loc123", cid: "location-cid" },
+      });
+      // Mock createRecord for collection
+      mockAgent.com.atproto.repo.createRecord.mockResolvedValueOnce({
+        success: true,
+        data: { uri: "at://did:plc:test/org.hypercerts.collection/xyz", cid: "collection-cid" },
+      });
+
+      const result = await hypercertOps.createCollection({
+        title: "My Collection",
+        items: [],
+        location: {
+          lpVersion: "1.0",
+          srs: "EPSG:4326",
+          locationType: "coordinate-decimal",
+          location: "https://example.com/loc",
+        },
+      });
+
+      expect(result.uri).toContain("collection");
+      expect(result.record.location?.uri).toBe("at://did:plc:test/app.certified.location/loc123");
+      // Should have created location first
+      expect(mockAgent.com.atproto.repo.createRecord).toHaveBeenCalledWith(
+        expect.objectContaining({
+          collection: "app.certified.location",
+        }),
+      );
     });
   });
 
@@ -874,9 +991,11 @@ describe("HypercertOperationsImpl", () => {
   });
 
   describe("Project Operations", () => {
-    // Projects are now collections with type='project'
+    // Projects are collections with type='project'
+    // createProject now calls createCollection with type="project" in a single step
     describe("createProject", () => {
       beforeEach(() => {
+        // Mock createRecord for createCollection call
         mockAgent.com.atproto.repo.createRecord.mockResolvedValue({
           success: true,
           data: { uri: "at://did:plc:test/org.hypercerts.claim.collection/abc123", cid: "project-cid" },
@@ -886,7 +1005,7 @@ describe("HypercertOperationsImpl", () => {
       it("should create a project with required fields only", async () => {
         const result = await hypercertOps.createProject({
           title: "Test Project",
-          shortDescription: "A test project for unit testing",
+          items: [],
         });
 
         expect(result.uri).toBe("at://did:plc:test/org.hypercerts.claim.collection/abc123");
@@ -898,8 +1017,6 @@ describe("HypercertOperationsImpl", () => {
               $type: "org.hypercerts.claim.collection",
               type: "project",
               title: "Test Project",
-              shortDescription: "A test project for unit testing",
-              items: [],
               createdAt: expect.any(String),
             }),
           }),
@@ -907,27 +1024,23 @@ describe("HypercertOperationsImpl", () => {
       });
 
       it("should create a project with all optional fields", async () => {
-        const description = { type: "linearDocument", content: "Rich text" };
-        const activities = [
-          { uri: "at://activity1", cid: "cid1", weight: "50" },
-          { uri: "at://activity2", cid: "cid2", weight: "50" },
+        const description = { blocks: [] };
+        const items = [
+          { itemIdentifier: { uri: "at://activity1", cid: "cid1" }, itemWeight: "50" },
+          { itemIdentifier: { uri: "at://activity2", cid: "cid2" }, itemWeight: "50" },
         ];
 
         const result = await hypercertOps.createProject({
           title: "Complete Project",
           shortDescription: "A complete project with all fields",
           description,
-          activities,
+          items,
         });
 
         expect(result.uri).toBeDefined();
         const createCall = mockAgent.com.atproto.repo.createRecord.mock.calls[0][0];
         expect(createCall.record.description).toEqual(description);
-        // Activities are mapped to items in collection schema
-        expect(createCall.record.items).toEqual([
-          { itemIdentifier: { uri: "at://activity1", cid: "cid1" }, itemWeight: "50" },
-          { itemIdentifier: { uri: "at://activity2", cid: "cid2" }, itemWeight: "50" },
-        ]);
+        expect(createCall.record.items).toEqual(items);
       });
 
       it("should upload avatar blob when provided", async () => {
@@ -936,7 +1049,7 @@ describe("HypercertOperationsImpl", () => {
           success: true,
           data: {
             blob: {
-              ref: { toString: () => "avatar-cid" },
+              ref: { $link: "avatar-cid" },
               mimeType: "image/png",
               size: 100,
             },
@@ -945,17 +1058,15 @@ describe("HypercertOperationsImpl", () => {
 
         await hypercertOps.createProject({
           title: "Project with Avatar",
-          shortDescription: "Project with avatar",
+          items: [],
           avatar: avatarBlob,
         });
 
         expect(mockAgent.com.atproto.repo.uploadBlob).toHaveBeenCalled();
         const createCall = mockAgent.com.atproto.repo.createRecord.mock.calls[0][0];
         expect(createCall.record.avatar).toEqual({
-          $type: "blob",
-          ref: { $link: "avatar-cid" },
-          mimeType: "image/png",
-          size: 100,
+          $type: "org.hypercerts.defs#smallImage",
+          image: { ref: { $link: "avatar-cid" }, mimeType: "image/png", size: 100 },
         });
       });
 
@@ -965,7 +1076,7 @@ describe("HypercertOperationsImpl", () => {
           success: true,
           data: {
             blob: {
-              ref: { toString: () => "banner-cid" },
+              ref: { $link: "banner-cid" },
               mimeType: "image/jpeg",
               size: 200,
             },
@@ -974,17 +1085,15 @@ describe("HypercertOperationsImpl", () => {
 
         await hypercertOps.createProject({
           title: "Project with Banner",
-          shortDescription: "Project with banner image",
+          items: [],
           banner: bannerBlob,
         });
 
         expect(mockAgent.com.atproto.repo.uploadBlob).toHaveBeenCalled();
         const createCall = mockAgent.com.atproto.repo.createRecord.mock.calls[0][0];
         expect(createCall.record.banner).toEqual({
-          $type: "blob",
-          ref: { $link: "banner-cid" },
-          mimeType: "image/jpeg",
-          size: 200,
+          $type: "org.hypercerts.defs#largeImage",
+          image: { ref: { $link: "banner-cid" }, mimeType: "image/jpeg", size: 200 },
         });
       });
 
@@ -1008,7 +1117,7 @@ describe("HypercertOperationsImpl", () => {
 
         await hypercertOps.createProject({
           title: "Full Project",
-          shortDescription: "Project with both images",
+          items: [],
           avatar: avatarBlob,
           banner: bannerBlob,
         });
@@ -1019,22 +1128,19 @@ describe("HypercertOperationsImpl", () => {
         expect(createCall.record.banner).toBeDefined();
       });
 
-      it("should transform activities array to items format", async () => {
+      it("should pass items array to record", async () => {
+        const items = [
+          { itemIdentifier: { uri: "at://act1", cid: "cid1" }, itemWeight: "30" },
+          { itemIdentifier: { uri: "at://act2", cid: "cid2" }, itemWeight: "70" },
+        ];
+
         await hypercertOps.createProject({
-          title: "Project with Activities",
-          shortDescription: "Project with activities",
-          activities: [
-            { uri: "at://act1", cid: "cid1", weight: "30" },
-            { uri: "at://act2", cid: "cid2", weight: "70" },
-          ],
+          title: "Project with Items",
+          items,
         });
 
         const createCall = mockAgent.com.atproto.repo.createRecord.mock.calls[0][0];
-        // Activities are mapped to items in collection schema
-        expect(createCall.record.items).toEqual([
-          { itemIdentifier: { uri: "at://act1", cid: "cid1" }, itemWeight: "30" },
-          { itemIdentifier: { uri: "at://act2", cid: "cid2" }, itemWeight: "70" },
-        ]);
+        expect(createCall.record.items).toEqual(items);
       });
 
       it("should emit projectCreated event", async () => {
@@ -1043,7 +1149,7 @@ describe("HypercertOperationsImpl", () => {
 
         await hypercertOps.createProject({
           title: "Event Test",
-          shortDescription: "Testing event emission",
+          items: [],
         });
 
         expect(handler).toHaveBeenCalledWith({
@@ -1060,7 +1166,7 @@ describe("HypercertOperationsImpl", () => {
         await expect(
           hypercertOps.createProject({
             title: "Failing Project",
-            shortDescription: "This will fail",
+            items: [],
           }),
         ).rejects.toThrow(NetworkError);
       });
@@ -1075,7 +1181,7 @@ describe("HypercertOperationsImpl", () => {
         await expect(
           hypercertOps.createProject({
             title: "Project",
-            shortDescription: "Project",
+            items: [],
             avatar: avatarBlob,
           }),
         ).rejects.toThrow(NetworkError);
@@ -1507,10 +1613,8 @@ describe("HypercertOperationsImpl", () => {
         expect(mockAgent.com.atproto.repo.uploadBlob).toHaveBeenCalled();
         const putCall = mockAgent.com.atproto.repo.putRecord.mock.calls[0][0];
         expect(putCall.record.avatar).toEqual({
-          $type: "blob",
-          ref: mockRef,
-          mimeType: "image/png",
-          size: 150,
+          $type: "org.hypercerts.defs#smallImage",
+          image: { ref: mockRef, mimeType: "image/png", size: 150 },
         });
       });
 
@@ -1532,29 +1636,25 @@ describe("HypercertOperationsImpl", () => {
         expect(putCall.record.banner).toBeDefined();
       });
 
-      it("should update activities array", async () => {
-        const newActivities = [
-          { uri: "at://new-act1", cid: "new-cid1", weight: "40" },
-          { uri: "at://new-act2", cid: "new-cid2", weight: "60" },
+      it("should update items array", async () => {
+        const newItems = [
+          { itemIdentifier: { uri: "at://new-act1", cid: "new-cid1" }, itemWeight: "40" },
+          { itemIdentifier: { uri: "at://new-act2", cid: "new-cid2" }, itemWeight: "60" },
         ];
 
         await hypercertOps.updateProject("at://did:plc:test/org.hypercerts.claim.collection/abc123", {
-          activities: newActivities,
+          items: newItems,
         });
 
         const putCall = mockAgent.com.atproto.repo.putRecord.mock.calls[0][0];
-        // Activities are mapped to items in collection schema
-        expect(putCall.record.items).toEqual([
-          { itemIdentifier: { uri: "at://new-act1", cid: "new-cid1" }, itemWeight: "40" },
-          { itemIdentifier: { uri: "at://new-act2", cid: "new-cid2" }, itemWeight: "60" },
-        ]);
+        expect(putCall.record.items).toEqual(newItems);
       });
 
       it("should update multiple fields at once", async () => {
         await hypercertOps.updateProject("at://did:plc:test/org.hypercerts.claim.collection/abc123", {
           title: "Multi Update",
           shortDescription: "Updated multiple fields",
-          activities: [{ uri: "at://act", cid: "cid", weight: "100" }],
+          items: [{ itemIdentifier: { uri: "at://act", cid: "cid" }, itemWeight: "100" }],
         });
 
         const putCall = mockAgent.com.atproto.repo.putRecord.mock.calls[0][0];
@@ -1622,6 +1722,46 @@ describe("HypercertOperationsImpl", () => {
         await expect(
           hypercertOps.updateProject("at://did:plc:test/org.hypercerts.claim.collection/fav", { title: "New" }),
         ).rejects.toThrow(ValidationError);
+      });
+
+      it("should throw ValidationError for invalid collection data", async () => {
+        const { validate } = await import("@hypercerts-org/lexicon");
+        const mockValidate = validate as ReturnType<typeof vi.fn>;
+
+        // Mock successful getRecord (already set in beforeEach, but let's be explicit)
+        mockAgent.com.atproto.repo.getRecord.mockResolvedValue({
+          success: true,
+          data: {
+            uri: "at://did:plc:test/org.hypercerts.claim.collection/abc123",
+            cid: "cid",
+            value: {
+              $type: "org.hypercerts.claim.collection",
+              type: "project",
+              title: "Old Title",
+              items: [],
+              createdAt: "2024-01-01T00:00:00Z",
+            },
+          },
+        });
+
+        // updateProject flow:
+        // 1. getRecord in updateProject (no validation)
+        // 2. updateCollection getRecord (no validation - reads directly)
+        // 3. validation before putRecord in updateCollection (line 1709) - should fail here
+        mockValidate.mockReturnValueOnce({
+          success: false,
+          error: { message: "Invalid title format" },
+        }); // Validation before putRecord - should fail
+
+        const result = hypercertOps.updateProject("at://did:plc:test/org.hypercerts.claim.collection/abc123", {
+          title: "", // Invalid: empty title
+        });
+
+        await expect(result).rejects.toThrow(ValidationError);
+        await expect(result).rejects.toThrow("Invalid collection record");
+
+        // Reset mock to default success behavior for other tests
+        mockValidate.mockReturnValue({ success: true });
       });
     });
 

--- a/packages/sdk-react/eslint.config.mjs
+++ b/packages/sdk-react/eslint.config.mjs
@@ -19,4 +19,7 @@ export default [
       },
     },
   },
+  {
+    ignores: ["vitest.config.ts"],
+  },
 ];

--- a/packages/sdk-react/src/types.ts
+++ b/packages/sdk-react/src/types.ts
@@ -393,7 +393,11 @@ export interface UseHypercertResult {
 // Project Types
 // ─────────────────────────────────────────────
 
-export type Project = HypercertProjectWithMetadata;
+export type Project = {
+  uri: string;
+  cid: string;
+  record: HypercertProjectWithMetadata;
+};
 
 /**
  * Result of the useProjects hook.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,11 +63,14 @@ importers:
         specifier: ^0.3.12
         version: 0.3.12
       '@hypercerts-org/lexicon':
-        specifier: 0.10.0-beta.10
-        version: 0.10.0-beta.10(@atproto/xrpc@0.7.6)
+        specifier: 0.10.0-beta.11
+        version: 0.10.0-beta.11(@atproto/xrpc@0.7.6)
       eventemitter3:
         specifier: ^5.0.1
         version: 5.0.1
+      type-fest:
+        specifier: ^5.4.1
+        version: 5.4.1
       zod:
         specifier: ^3.24.4
         version: 3.25.76
@@ -154,8 +157,8 @@ packages:
   '@atcute/bluesky@3.2.15':
     resolution: {integrity: sha512-H4RW3WffjfdKvOZ9issEUQnuSR4KfuAwwJnYu0fclA9VDa99JTJ+pa8tTl9lFeBV9DINtWJAx7rdIbICoVCstQ==}
 
-  '@atcute/leaflet@1.0.15':
-    resolution: {integrity: sha512-soA4jGsY0UxTar8rhtfQNYFXPI+qoQGgjpeMKJaO8ZCBBMRoo4OU9gsFJpUm/BYSocOBvvWSq2GV9pYEgUehTw==}
+  '@atcute/leaflet@1.0.16':
+    resolution: {integrity: sha512-YS0+93C+bG2AlB1M5Cvf8v7GMnP/67l5G+RUQQltXydqugcAEW6ZgasXN/ZlsTJJl5tdWBTS4HsRYwdS576SkA==}
 
   '@atcute/lexicons@1.2.6':
     resolution: {integrity: sha512-s76UQd8D+XmHIzrjD9CJ9SOOeeLPHc+sMmcj7UFakAW/dDFXc579fcRdRfuUKvXBL5v1Gs2VgDdlh/IvvQZAwA==}
@@ -198,11 +201,11 @@ packages:
   '@atproto/api@0.17.7':
     resolution: {integrity: sha512-V+OJBZq9chcrD21xk1bUa6oc5DSKfQj5DmUPf5rmZncqL1w9ZEbS38H5cMyqqdhfgo2LWeDRdZHD0rvNyJsIaw==}
 
+  '@atproto/common-web@0.4.12':
+    resolution: {integrity: sha512-3aCJemqM/fkHQrVPbTCHCdiVstKFI+2LkFLvUhO6XZP0EqUZa/rg/CIZBKTFUWu9I5iYiaEiXL9VwcDRpEevSw==}
+
   '@atproto/common-web@0.4.5':
     resolution: {integrity: sha512-Tx0xUafLm3vRvOQpbBl5eb9V8xlC7TaRXs6dAulHRkDG3Kb+P9qn3pkDteq+aeMshbVXbVa1rm3Ok4vFyuoyYA==}
-
-  '@atproto/common-web@0.4.9':
-    resolution: {integrity: sha512-RGt1rUjVC8FEUlF5JQyN3xYlqZJbFTN0XSBBxl+HozjZGhhVtAVFGa+F+TR6BCVs7q7TcitOv/y/YWz4jJWn9g==}
 
   '@atproto/did@0.2.3':
     resolution: {integrity: sha512-VI8JJkSizvM2cHYJa37WlbzeCm5tWpojyc1/Zy8q8OOjyoy6X4S4BEfoP941oJcpxpMTObamibQIXQDo7tnIjg==}
@@ -219,14 +222,14 @@ packages:
   '@atproto/lex-data@0.0.1':
     resolution: {integrity: sha512-DrS/8cQcQs3s5t9ELAFNtyDZ8/PdiCx47ALtFEP2GnX2uCBHZRkqWG7xmu6ehjc787nsFzZBvlnz3T/gov5fGA==}
 
-  '@atproto/lex-data@0.0.5':
-    resolution: {integrity: sha512-nasD4eo2wKLyhHozC0vy7Jhp/fBwCKnYhQQogYtraUlT9il6lK1drhT8CNpWlglOhb0T73jLG5WpfNsPp6Pr/w==}
+  '@atproto/lex-data@0.0.8':
+    resolution: {integrity: sha512-1Y5tz7BkS7380QuLNXaE8GW8Xba+mRWugt8BKM4BUFYjjUZdmirU8lr72iM4XlEBrzRu8Cfvj+MbsbYaZv+IgA==}
 
   '@atproto/lex-json@0.0.1':
     resolution: {integrity: sha512-ivcF7+pDRuD/P97IEKQ/9TruunXj0w58Khvwk3M6psaI5eZT6LRsRZ4cWcKaXiFX4SHnjy+x43g0f7pPtIsERg==}
 
-  '@atproto/lex-json@0.0.5':
-    resolution: {integrity: sha512-wgmET7fIWi77jxqHnrr0RvpAGhiFqIqjdO9Py3JK2whHMITyYgFRU0HfEtIeWSzx0Vb9z0S7F/fQW3P3gqb+yA==}
+  '@atproto/lex-json@0.0.8':
+    resolution: {integrity: sha512-w1Qmkae1QhmNz+i1Zm3xr3jp0UPPRENmdlpU0qIrdxWDo9W4Mzkeyc3eSoa+Zs+zN8xkRSQw7RLZte/B7Ipdwg==}
 
   '@atproto/lexicon@0.5.2':
     resolution: {integrity: sha512-lRmJgMA8f5j7VB5Iu5cp188ald5FuI4FlmZ7nn6EBrk1dgOstWVrI5Ft6K3z2vjyLZRG6nzknlsw+tDP63p7bQ==}
@@ -257,6 +260,10 @@ packages:
     resolution: {integrity: sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/code-frame@7.28.6':
+    resolution: {integrity: sha512-JYgintcMjRiCvS8mMECzaEn+m3PfoQiyqukOMCCVQtoJGYJw8j/8LBJEiqkHLkfwCcs74E3pbAUFNg7d9VNJ+Q==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-string-parser@7.27.1':
     resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
     engines: {node: '>=6.9.0'}
@@ -272,6 +279,10 @@ packages:
 
   '@babel/runtime@7.28.4':
     resolution: {integrity: sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/runtime@7.28.6':
+    resolution: {integrity: sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==}
     engines: {node: '>=6.9.0'}
 
   '@babel/types@7.28.5':
@@ -581,8 +592,8 @@ packages:
     resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
     engines: {node: '>=18.18'}
 
-  '@hypercerts-org/lexicon@0.10.0-beta.10':
-    resolution: {integrity: sha512-bha+8AYCx/ZA41O3pqYVFyZ9Yr+ipcIRtLqOChdhoLW/np3Qt857bggyRc2+goealGVKDU0jeQuazXZaZD2S6Q==}
+  '@hypercerts-org/lexicon@0.10.0-beta.11':
+    resolution: {integrity: sha512-+fbxQ/22qHrJ+l9q4kp/QiC9dKyLFaXbin5WPvbUkeMVHaZyhw2G/GE8O0QWksFNtCdUpDjjD7tWs0AWk934aQ==}
     peerDependencies:
       '@atproto/xrpc': '*'
 
@@ -1911,6 +1922,10 @@ packages:
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
 
+  tagged-tag@1.0.0:
+    resolution: {integrity: sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==}
+    engines: {node: '>=20'}
+
   term-size@2.2.1:
     resolution: {integrity: sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg==}
     engines: {node: '>=8'}
@@ -2006,6 +2021,10 @@ packages:
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
+
+  type-fest@5.4.1:
+    resolution: {integrity: sha512-xygQcmneDyzsEuKZrFbRMne5HDqMs++aFzefrJTgEIKjQ3rekM+RPfFCVq2Gp1VIDqddoYeppCj4Pcb+RZW0GQ==}
+    engines: {node: '>=20'}
 
   typescript-eslint@8.48.0:
     resolution: {integrity: sha512-fcKOvQD9GUn3Xw63EgiDqhvWJ5jsyZUaekl3KVpGsDJnN46WJTe3jWxtQP9lMZm1LJNkFLlTaWAxK2vUQR+cqw==}
@@ -2213,7 +2232,7 @@ snapshots:
       '@atcute/atproto': 3.1.10
       '@atcute/lexicons': 1.2.6
 
-  '@atcute/leaflet@1.0.15':
+  '@atcute/leaflet@1.0.16':
     dependencies:
       '@atcute/atproto': 3.1.10
       '@atcute/lexicons': 1.2.6
@@ -2289,16 +2308,16 @@ snapshots:
       tlds: 1.261.0
       zod: 3.25.76
 
+  '@atproto/common-web@0.4.12':
+    dependencies:
+      '@atproto/lex-data': 0.0.8
+      '@atproto/lex-json': 0.0.8
+      zod: 3.25.76
+
   '@atproto/common-web@0.4.5':
     dependencies:
       '@atproto/lex-data': 0.0.1
       '@atproto/lex-json': 0.0.1
-      zod: 3.25.76
-
-  '@atproto/common-web@0.4.9':
-    dependencies:
-      '@atproto/lex-data': 0.0.5
-      '@atproto/lex-json': 0.0.5
       zod: 3.25.76
 
   '@atproto/did@0.2.3':
@@ -2329,7 +2348,7 @@ snapshots:
       uint8arrays: 3.0.0
       unicode-segmenter: 0.14.0
 
-  '@atproto/lex-data@0.0.5':
+  '@atproto/lex-data@0.0.8':
     dependencies:
       '@atproto/syntax': 0.4.2
       multiformats: 9.9.0
@@ -2342,9 +2361,9 @@ snapshots:
       '@atproto/lex-data': 0.0.1
       tslib: 2.8.1
 
-  '@atproto/lex-json@0.0.5':
+  '@atproto/lex-json@0.0.8':
     dependencies:
-      '@atproto/lex-data': 0.0.5
+      '@atproto/lex-data': 0.0.8
       tslib: 2.8.1
 
   '@atproto/lexicon@0.5.2':
@@ -2357,7 +2376,7 @@ snapshots:
 
   '@atproto/lexicon@0.6.0':
     dependencies:
-      '@atproto/common-web': 0.4.9
+      '@atproto/common-web': 0.4.12
       '@atproto/syntax': 0.4.2
       iso-datestring-validator: 2.2.2
       multiformats: 9.9.0
@@ -2411,6 +2430,13 @@ snapshots:
       '@babel/helper-validator-identifier': 7.28.5
       js-tokens: 4.0.0
       picocolors: 1.1.1
+    optional: true
+
+  '@babel/code-frame@7.28.6':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.28.5
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
 
   '@babel/helper-string-parser@7.27.1': {}
 
@@ -2421,6 +2447,8 @@ snapshots:
       '@babel/types': 7.28.5
 
   '@babel/runtime@7.28.4': {}
+
+  '@babel/runtime@7.28.6': {}
 
   '@babel/types@7.28.5':
     dependencies:
@@ -2743,10 +2771,10 @@ snapshots:
 
   '@humanwhocodes/retry@0.4.3': {}
 
-  '@hypercerts-org/lexicon@0.10.0-beta.10(@atproto/xrpc@0.7.6)':
+  '@hypercerts-org/lexicon@0.10.0-beta.11(@atproto/xrpc@0.7.6)':
     dependencies:
       '@atcute/bluesky': 3.2.15
-      '@atcute/leaflet': 1.0.15
+      '@atcute/leaflet': 1.0.16
       '@atproto/lexicon': 0.6.0
       '@atproto/xrpc': 0.7.6
       multiformats: 13.4.2
@@ -2931,8 +2959,8 @@ snapshots:
 
   '@testing-library/dom@10.4.1':
     dependencies:
-      '@babel/code-frame': 7.27.1
-      '@babel/runtime': 7.28.4
+      '@babel/code-frame': 7.28.6
+      '@babel/runtime': 7.28.6
       '@types/aria-query': 5.0.4
       aria-query: 5.3.0
       dom-accessibility-api: 0.5.16
@@ -4060,6 +4088,8 @@ snapshots:
 
   symbol-tree@3.2.4: {}
 
+  tagged-tag@1.0.0: {}
+
   term-size@2.2.1: {}
 
   tinybench@2.9.0: {}
@@ -4133,6 +4163,10 @@ snapshots:
   type-check@0.4.0:
     dependencies:
       prelude-ls: 1.2.1
+
+  type-fest@5.4.1:
+    dependencies:
+      tagged-tag: 1.0.0
 
   typescript-eslint@8.48.0(eslint@9.39.1)(typescript@5.9.3):
     dependencies:


### PR DESCRIPTION
Before this fix, collection/project types used non-lexicon field names like
'claims'/'activities' instead of the correct 'items', and returned improper
formats for avatar/banner images and location data. They also didn't use
types from the lexicons package.

This fix:
- Updates CreateCollectionParams/UpdateCollectionParams to use correct
  lexicon field names (items, banner, avatar) with proper types
- Adds resolveCollectionImageInput() helper for correct image format
  (smallImage/largeImage with $type fields)
- Adds resolveLocation() helper supporting string|Blob inputs
- Fixes Project type in sdk-react to include uri/cid/record wrapper
- Updates all tests to use correct lexicon format and field names

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Full collection CRUD, project creation (projects now behave as collections), attach/remove locations, avatar/banner handling, and item-based collection contents.

* **API Changes**
  * Typed params/results; create/update use items (not claims/activities); image inputs accept string or Blob; project payloads expose uri/cid with nested record; location attach accepts ref/string/object and may return a location URI.

* **Events**
  * New collection- and location-related lifecycle events.

* **Tests**
  * Updated for items, images, locations, and validation.

* **Documentation**
  * Expanded Collections & Projects guides and API reference.

* **Chores**
  * Lint/ignore and changeset/workflow updates.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->