### PR TITLE
ci: try again to fix release process

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,11 +13,11 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "typecheck": "turbo typecheck",
-    "check": "turbo check",
+    "check": "pnpm run lint && pnpm run typecheck && pnpm run build && pnpm run test",
     "clean": "turbo clean",
     "changeset": "changeset",
     "version-packages": "changeset version",
-    "release": "turbo check && changeset publish",
+    "release": "pnpm check && changeset publish",
     "prepare": "husky"
   },
   "devDependencies": {

--- a/packages/sdk-react/package.json
+++ b/packages/sdk-react/package.json
@@ -18,7 +18,7 @@
     "README.md",
     "CHANGELOG.md"
   ],
-  "prepublishOnly": "npm run lint && pnpm run typecheck && pnpm run build && pnpm run test",
+  "prepublishOnly": "pnpm run lint && pnpm run typecheck && pnpm run build && pnpm run test",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",


### PR DESCRIPTION
Turns out `prepublishOnly` wasn't causing the hang, it was the call to
`turbo check`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated development and release workflow scripts to standardize package manager usage across the project
  * Enhanced build verification process to include comprehensive sequential checks: linting, type validation, compilation, and testing

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->