### PR TITLE
Autogenerate the activity claim's rKey

### DIFF
--- a/.changeset/support-multiple-locations.md
+++ b/.changeset/support-multiple-locations.md
@@ -1,0 +1,54 @@
+---
+"@hypercerts-org/sdk-core": minor
+---
+
+Support multiple locations for hypercert activity claims
+
+**Breaking Changes:**
+
+- `CreateHypercertParams.location` is now `CreateHypercertParams.locations` (plural, array)
+- `CreateHypercertResult.locationUri` is now `CreateHypercertResult.locationUris` (plural, array)
+- `CreateHypercertResult.locationCid` is now `CreateHypercertResult.locationCids` (plural, array)
+
+**New Functionality:**
+
+- Hypercerts can now have multiple locations to support activities spanning multiple places
+- Each location can be a StrongRef, string URI, or location object
+- `attachLocation()` now appends to existing locations array instead of replacing
+
+**Migration:**
+
+```typescript
+// Before (v0.10.0-beta.5 and earlier)
+await repo.hypercerts.create({
+  ...params,
+  location: {
+    lpVersion: "1.0.0",
+    srs: "EPSG:4326",
+    locationType: "coordinate-decimal",
+    location: "https://example.com/location",
+  },
+});
+
+// After (v0.10.0-beta.6+)
+await repo.hypercerts.create({
+  ...params,
+  locations: [
+    {
+      lpVersion: "1.0.0",
+      srs: "EPSG:4326",
+      locationType: "coordinate-decimal",
+      location: "https://example.com/location",
+    },
+  ],
+});
+
+// Now supports multiple locations
+await repo.hypercerts.create({
+  ...params,
+  locations: [
+    { location: "https://example.com/location1", ... },
+    { location: "https://example.com/location2", ... },
+  ],
+});
+```

--- a/.changeset/wise-papayas-sing.md
+++ b/.changeset/wise-papayas-sing.md
@@ -3,3 +3,6 @@
 ---
 
 feat: implement pre-generation of rKeys for activity claims using deterministic content hashing (SHA-256).
+
+fix: normalize hashInput in `createHypercertRecord()` to use resolved StrongRefs (`locationRef`, `contributorsData`)
+instead of raw params which may contain non-serializable Blobs or inconsistent formats, ensuring stable rKey generation.

--- a/.changeset/wise-papayas-sing.md
+++ b/.changeset/wise-papayas-sing.md
@@ -1,0 +1,5 @@
+---
+"@hypercerts-org/sdk-core": minor
+---
+
+feat: implement pre-generation of rKeys for activity claims using deterministic content hashing (SHA-256).

--- a/packages/sdk-core/README.md
+++ b/packages/sdk-core/README.md
@@ -41,8 +41,8 @@ const claim = await repo.hypercerts.create({
   shortDescription: "1000 trees planted in rainforest",
   description: "Planted 1000 trees in the Amazon rainforest region",
   workScope: "Environmental Conservation",
-  workTimeFrameFrom: "2025-01-01T00:00:00Z",
-  workTimeFrameTo: "2025-12-31T23:59:59Z",
+  startDate: "2025-01-01",
+  endDate: "2025-12-31",
   rights: {
     name: "Attribution",
     type: "license",

--- a/packages/sdk-core/src/lib/crypto.ts
+++ b/packages/sdk-core/src/lib/crypto.ts
@@ -2,7 +2,7 @@
  * Crypto utilities for the SDK.
  */
 
-import { NetworkError } from "../core/errors.js";
+import { NetworkError, ValidationError } from "../core/errors.js";
 
 /**
  * Deterministically stringifies an object by sorting keys recursively.
@@ -43,10 +43,16 @@ export function stableStringify(obj: unknown): string | undefined {
  *
  * @param content - The content to hash (will be JSON serialized)
  * @returns The SHA-256 hash of the content
+ * @throws {ValidationError} If content is not serializable (e.g. undefined, function, symbol)
  */
 export async function sha256Hash(content: unknown): Promise<string> {
     // Use stable stringification to ensure deterministic output
-    const jsonString = stableStringify(content) ?? "";
+    const jsonString = stableStringify(content);
+
+    if (jsonString === undefined) {
+        throw new ValidationError(`Content illegal: not serializable (type: ${typeof content})`);
+    }
+
     const msgBuffer = new TextEncoder().encode(jsonString);
 
     if (typeof crypto !== "undefined" && crypto.subtle) {

--- a/packages/sdk-core/src/lib/crypto.ts
+++ b/packages/sdk-core/src/lib/crypto.ts
@@ -1,0 +1,69 @@
+/**
+ * Crypto utilities for the SDK.
+ */
+
+import { NetworkError } from "../core/errors.js";
+
+/**
+ * Deterministically stringifies an object by sorting keys recursively.
+ * Handles deeply nested objects and null values correctly.
+ */
+function stableStringify(obj: unknown): string | undefined {
+    if (obj === undefined || typeof obj === "function" || typeof obj === "symbol") {
+        return undefined;
+    }
+    if (obj === null || typeof obj !== "object") {
+        return JSON.stringify(obj);
+    }
+
+    if (Array.isArray(obj)) {
+        return JSON.stringify(obj.map((item) => {
+            const val = stableStringify(item);
+            return val === undefined ? null : JSON.parse(val);
+        }));
+    }
+
+    const sortedKeys = Object.keys(obj as object).sort();
+    const sortedObj: Record<string, unknown> = {};
+
+    for (const key of sortedKeys) {
+        const value = (obj as Record<string, unknown>)[key];
+        const str = stableStringify(value);
+        // Skip undefined or non-serializable values
+        if (str === undefined) continue;
+        sortedObj[key] = JSON.parse(str);
+    }
+
+    return JSON.stringify(sortedObj);
+}
+
+/**
+ * Computes the SHA-256 hash of a JSON-serializable object.
+ * Returns the hash as a hexadecimal string.
+ *
+ * @param content - The content to hash (will be JSON serialized)
+ * @returns The SHA-256 hash of the content
+ */
+export async function sha256Hash(content: unknown): Promise<string> {
+    // Use stable stringification to ensure deterministic output
+    const jsonString = stableStringify(content) ?? "";
+    const msgBuffer = new TextEncoder().encode(jsonString);
+
+    if (typeof crypto !== "undefined" && crypto.subtle) {
+        // Browser / Modern Node.js
+        const hashBuffer = await crypto.subtle.digest("SHA-256", msgBuffer);
+        const hashArray = Array.from(new Uint8Array(hashBuffer));
+        return hashArray.map((b) => b.toString(16).padStart(2, "0")).join("");
+    } else {
+        // Fallback for older environments or specific setups if global crypto isn't available
+        try {
+            // Dynamic import to avoid breaking browser builds if bundler doesn't handle it
+             
+            const { createHash } = await import("node:crypto");
+            const hash = createHash("sha256").update(jsonString).digest("hex");
+            return hash;
+        } catch (e) {
+            throw new NetworkError("SHA-256 hashing not supported in this environment", e);
+        }
+    }
+}

--- a/packages/sdk-core/src/lib/crypto.ts
+++ b/packages/sdk-core/src/lib/crypto.ts
@@ -8,7 +8,7 @@ import { NetworkError } from "../core/errors.js";
  * Deterministically stringifies an object by sorting keys recursively.
  * Handles deeply nested objects and null values correctly.
  */
-function stableStringify(obj: unknown): string | undefined {
+export function stableStringify(obj: unknown): string | undefined {
     if (obj === undefined || typeof obj === "function" || typeof obj === "symbol") {
         return undefined;
     }
@@ -58,7 +58,7 @@ export async function sha256Hash(content: unknown): Promise<string> {
         // Fallback for older environments or specific setups if global crypto isn't available
         try {
             // Dynamic import to avoid breaking browser builds if bundler doesn't handle it
-             
+
             const { createHash } = await import("node:crypto");
             const hash = createHash("sha256").update(jsonString).digest("hex");
             return hash;

--- a/packages/sdk-core/src/repository/HypercertOperationsImpl.ts
+++ b/packages/sdk-core/src/repository/HypercertOperationsImpl.ts
@@ -298,14 +298,15 @@ export class HypercertOperationsImpl extends EventEmitter<HypercertEvents> imple
     }
 
     // Generate rKey from stable content hash (idempotency)
-    // We hash the user's intent (params + rights definition), not the volatile outputs (like new rights CID or createdAt)
-
-    // Destructure to remove non-hashable/redundant fields (image, onProgress)
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const { image, onProgress: _onProgress, ...paramsForHash } = params;
-
+    // Hash only the fields that end up in the claim record itself, plus image blob ref and rights data.
+    // Excludes sidecar data (location, contributions, evidence) to keep rKeys stable.
     const hashInput = {
-      ...paramsForHash,
+      title: params.title,
+      description: params.description,
+      shortDescription: params.shortDescription,
+      workScope: params.workScope,
+      startDate: params.startDate,
+      endDate: params.endDate,
       // Use the full image blob reference for identity (handled by stable stringify)
       imageRecord: imageBlobRef,
       // Ensure rights definition is part of identity, but not the new CID

--- a/packages/sdk-core/src/repository/HypercertOperationsImpl.ts
+++ b/packages/sdk-core/src/repository/HypercertOperationsImpl.ts
@@ -584,7 +584,6 @@ export class HypercertOperationsImpl extends EventEmitter<HypercertEvents> imple
       result.rightsCid = rightsCid;
 
       // Step 4: Build contributors data for embedding (if provided)
-      // Step 4: Build contributors data for embedding (if provided)
       let contributorsData:
         | Array<{ contributorIdentity: string; contributionDetails?: string | { uri: string; cid: string } }>
         | undefined;

--- a/packages/sdk-core/src/repository/HypercertOperationsImpl.ts
+++ b/packages/sdk-core/src/repository/HypercertOperationsImpl.ts
@@ -265,6 +265,7 @@ export class HypercertOperationsImpl extends EventEmitter<HypercertEvents> imple
     rightsCid: string,
     imageBlobRef: JsonBlobRef | undefined,
     locationRef: { uri: string; cid: string } | undefined,
+    contributorsData: Array<{ contributorIdentity: string; contributionDetails?: string }> | undefined,
     createdAt: string,
     onProgress?: (step: ProgressStep) => void,
   ): Promise<{ uri: string; cid: string }> {
@@ -298,13 +299,21 @@ export class HypercertOperationsImpl extends EventEmitter<HypercertEvents> imple
       hypercertRecord.descriptionFacets = params.descriptionFacets;
     }
 
+    // Add contributors if provided (embedded inline per lexicon)
+    if (contributorsData && contributorsData.length > 0) {
+      hypercertRecord.contributors = contributorsData.map((c) => ({
+        contributorIdentity: c.contributorIdentity,
+        contributionDetails: c.contributionDetails,
+      }));
+    }
+
     const hypercertValidation = validate(hypercertRecord, HYPERCERT_COLLECTIONS.CLAIM, "main", false);
     if (!hypercertValidation.success) {
       throw new ValidationError(`Invalid hypercert record: ${hypercertValidation.error?.message}`);
     }
 
     // Generate rKey from stable content hash (idempotency)
-    // Hash the complete claim record including all StrongRefs (rights, location)
+    // Hash the complete claim record including all StrongRefs and embedded data
     // These define the claim's identity per the lexicon.
     const hashInput = {
       title: params.title,
@@ -319,6 +328,8 @@ export class HypercertOperationsImpl extends EventEmitter<HypercertEvents> imple
       rightsData: typeof params.rights === "object" ? params.rights : undefined,
       // Location StrongRef - part of claim identity per lexicon
       locationRef: locationRef,
+      // Contributors - part of claim identity per lexicon
+      contributors: contributorsData,
     };
 
     const contentHash = await sha256Hash(hashInput);
@@ -562,31 +573,32 @@ export class HypercertOperationsImpl extends EventEmitter<HypercertEvents> imple
       result.rightsUri = rightsUri;
       result.rightsCid = rightsCid;
 
-      // Step 4: Create hypercert record (with embedded location and rights StrongRefs)
+      // Step 4: Build contributors data for embedding (if provided)
+      let contributorsData: Array<{ contributorIdentity: string; contributionDetails?: string }> | undefined;
+      if (params.contributions && params.contributions.length > 0) {
+        // Transform SDK contributions format to lexicon format
+        // Each contribution has multiple contributors, so we expand them
+        contributorsData = params.contributions.flatMap((contrib) =>
+          contrib.contributors.map((did) => ({
+            contributorIdentity: did,
+            contributionDetails: contrib.role,
+          })),
+        );
+      }
+
+      // Step 5: Create hypercert record (with embedded location, rights, and contributors)
       const { uri: hypercertUri, cid: hypercertCid } = await this.createHypercertRecord(
         params,
         rightsUri,
         rightsCid,
         imageBlobRef,
         locationRef,
+        contributorsData,
         createdAt,
         params.onProgress,
       );
       result.hypercertUri = hypercertUri;
       result.hypercertCid = hypercertCid;
-
-      // Step 5: Create contributions if provided
-      if (params.contributions && params.contributions.length > 0) {
-        try {
-          result.contributionUris = await this.createContributionsWithProgress(
-            hypercertUri,
-            params.contributions,
-            params.onProgress,
-          );
-        } catch {
-          // Error already logged and progress emitted
-        }
-      }
 
       // Step 6: Add evidence records if provided
       if (params.evidence && params.evidence.length > 0) {

--- a/packages/sdk-core/src/repository/HypercertOperationsImpl.ts
+++ b/packages/sdk-core/src/repository/HypercertOperationsImpl.ts
@@ -265,7 +265,9 @@ export class HypercertOperationsImpl extends EventEmitter<HypercertEvents> imple
     rightsCid: string,
     imageBlobRef: JsonBlobRef | undefined,
     locationRef: { uri: string; cid: string } | undefined,
-    contributorsData: Array<{ contributorIdentity: string; contributionDetails?: string }> | undefined,
+    contributorsData:
+      | Array<{ contributorIdentity: string; contributionDetails?: string | { uri: string; cid: string } }>
+      | undefined,
     createdAt: string,
     onProgress?: (step: ProgressStep) => void,
   ): Promise<{ uri: string; cid: string }> {
@@ -299,12 +301,18 @@ export class HypercertOperationsImpl extends EventEmitter<HypercertEvents> imple
       hypercertRecord.descriptionFacets = params.descriptionFacets;
     }
 
-    // Add contributors if provided (embedded inline per lexicon)
+    // Add contributors if provided (inline role string or StrongRef per lexicon)
     if (contributorsData && contributorsData.length > 0) {
-      hypercertRecord.contributors = contributorsData.map((c) => ({
-        contributorIdentity: c.contributorIdentity,
-        contributionDetails: c.contributionDetails,
-      }));
+      hypercertRecord.contributors = contributorsData.map((c) => {
+        const contributor: Record<string, unknown> = {
+          contributorIdentity: c.contributorIdentity,
+        };
+        if (c.contributionDetails) {
+          // StrongRef has uri/cid, string is inline role
+          contributor.contributionDetails = c.contributionDetails;
+        }
+        return contributor;
+      });
     }
 
     const hypercertValidation = validate(hypercertRecord, HYPERCERT_COLLECTIONS.CLAIM, "main", false);
@@ -576,16 +584,50 @@ export class HypercertOperationsImpl extends EventEmitter<HypercertEvents> imple
       result.rightsCid = rightsCid;
 
       // Step 4: Build contributors data for embedding (if provided)
-      let contributorsData: Array<{ contributorIdentity: string; contributionDetails?: string }> | undefined;
+      // Step 4: Build contributors data for embedding (if provided)
+      let contributorsData:
+        | Array<{ contributorIdentity: string; contributionDetails?: string | { uri: string; cid: string } }>
+        | undefined;
       if (params.contributions && params.contributions.length > 0) {
         // Transform SDK contributions format to lexicon format
-        // Each contribution has multiple contributors, so we expand them
-        contributorsData = params.contributions.flatMap((contrib) =>
-          contrib.contributors.map((did) => ({
+        // Handle async creation of contributionDetails records if description is provided
+        const contributorsPromises = params.contributions.map(async (contrib) => {
+          let detailsRef: string | { uri: string; cid: string } = contrib.role;
+
+          // If description is provided, create a detailed record
+          if (contrib.description) {
+            try {
+              this.emitProgress(params.onProgress, { name: "createContribution", status: "start" });
+              const result = await this.addContribution({
+                contributors: contrib.contributors, // Passed for legacy reasons/completeness
+                role: contrib.role,
+                description: contrib.description,
+              });
+              detailsRef = { uri: result.uri, cid: result.cid };
+              this.emitProgress(params.onProgress, {
+                name: "createContribution",
+                status: "success",
+                data: result,
+              });
+            } catch (error) {
+              this.emitProgress(params.onProgress, {
+                name: "createContribution",
+                status: "error",
+                error: error as Error,
+              });
+              throw error;
+            }
+          }
+
+          // Expand to one entry per contributor DID
+          return contrib.contributors.map((did) => ({
             contributorIdentity: did,
-            contributionDetails: contrib.role,
-          })),
-        );
+            contributionDetails: detailsRef,
+          }));
+        });
+
+        const nestedContributors = await Promise.all(contributorsPromises);
+        contributorsData = nestedContributors.flat();
       }
 
       // Step 5: Create hypercert record (with embedded location, rights, and contributors)

--- a/packages/sdk-core/src/repository/HypercertOperationsImpl.ts
+++ b/packages/sdk-core/src/repository/HypercertOperationsImpl.ts
@@ -44,6 +44,7 @@ import type {
 } from "./interfaces.js";
 import type { CreateResult, ListParams, PaginatedList, ProgressStep, UpdateResult } from "./types.js";
 import { $Typed } from "@atproto/api";
+import { sha256Hash } from "../lib/crypto.js";
 
 /**
  * Implementation of high-level hypercert operations.
@@ -296,10 +297,29 @@ export class HypercertOperationsImpl extends EventEmitter<HypercertEvents> imple
       throw new ValidationError(`Invalid hypercert record: ${hypercertValidation.error?.message}`);
     }
 
+    // Generate rKey from stable content hash (idempotency)
+    // We hash the user's intent (params + rights definition), not the volatile outputs (like new rights CID or createdAt)
+
+    // Destructure to remove non-hashable/redundant fields (image, onProgress)
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { image, onProgress: _onProgress, ...paramsForHash } = params;
+
+    const hashInput = {
+      ...paramsForHash,
+      // Use the full image blob reference for identity (handled by stable stringify)
+      imageRecord: imageBlobRef,
+      // Ensure rights definition is part of identity, but not the new CID
+      rightsData: typeof params.rights === "object" ? params.rights : undefined,
+    };
+
+    const contentHash = await sha256Hash(hashInput);
+    const rkey = `hc2:${contentHash}`;
+
     const hypercertResult = await this.agent.com.atproto.repo.createRecord({
       repo: this.repoDid,
       collection: HYPERCERT_COLLECTIONS.CLAIM,
       record: hypercertRecord,
+      rkey,
     });
 
     if (!hypercertResult.success) {

--- a/packages/sdk-core/src/repository/HypercertOperationsImpl.ts
+++ b/packages/sdk-core/src/repository/HypercertOperationsImpl.ts
@@ -556,24 +556,10 @@ export class HypercertOperationsImpl extends EventEmitter<HypercertEvents> imple
 
       // Step 2: Create location record if provided (must be before hypercert)
       // If location is provided, it must succeed - failing silently would change the rKey on retries
-      let locationRef: { uri: string; cid: string } | undefined;
-      if (params.location) {
-        try {
-          this.emitProgress(params.onProgress, { name: "createLocation", status: "start" });
-          locationRef = await this.resolveLocation(params.location);
-          result.locationUri = locationRef.uri;
-          result.locationCid = locationRef.cid;
-          this.emitProgress(params.onProgress, {
-            name: "createLocation",
-            status: "success",
-            data: { uri: locationRef.uri },
-          });
-        } catch (error) {
-          this.emitProgress(params.onProgress, { name: "createLocation", status: "error", error: error as Error });
-          this.logger?.warn(`Failed to create location: ${error instanceof Error ? error.message : "Unknown"}`);
-          // Re-throw to fail the operation - swallowing would change rKey on retry
-          throw error;
-        }
+      const locationRef = await this.processLocation(params.location, params.onProgress);
+      if (locationRef) {
+        result.locationUri = locationRef.uri;
+        result.locationCid = locationRef.cid;
       }
 
       // Step 3: Create rights record
@@ -586,50 +572,7 @@ export class HypercertOperationsImpl extends EventEmitter<HypercertEvents> imple
       result.rightsCid = rightsCid;
 
       // Step 4: Build contributors data for embedding (if provided)
-      let contributorsData:
-        | Array<{ contributorIdentity: string; contributionDetails?: string | { uri: string; cid: string } }>
-        | undefined;
-      if (params.contributions && params.contributions.length > 0) {
-        // Transform SDK contributions format to lexicon format
-        // Handle async creation of contributionDetails records if description is provided
-        const contributorsPromises = params.contributions.map(async (contrib) => {
-          let detailsRef: string | { uri: string; cid: string } = contrib.role;
-
-          // If description is provided, create a detailed record
-          if (contrib.description) {
-            try {
-              this.emitProgress(params.onProgress, { name: "createContribution", status: "start" });
-              const result = await this.addContribution({
-                contributors: contrib.contributors, // Passed for legacy reasons/completeness
-                role: contrib.role,
-                description: contrib.description,
-              });
-              detailsRef = { uri: result.uri, cid: result.cid };
-              this.emitProgress(params.onProgress, {
-                name: "createContribution",
-                status: "success",
-                data: result,
-              });
-            } catch (error) {
-              this.emitProgress(params.onProgress, {
-                name: "createContribution",
-                status: "error",
-                error: error as Error,
-              });
-              throw error;
-            }
-          }
-
-          // Expand to one entry per contributor DID
-          return contrib.contributors.map((did) => ({
-            contributorIdentity: did,
-            contributionDetails: detailsRef,
-          }));
-        });
-
-        const nestedContributors = await Promise.all(contributorsPromises);
-        contributorsData = nestedContributors.flat();
-      }
+      const contributorsData = await this.processContributors(params.contributions, params.onProgress);
 
       // Step 5: Create hypercert record (with embedded location, rights, and contributors)
       const { uri: hypercertUri, cid: hypercertCid } = await this.createHypercertRecord(
@@ -1149,6 +1092,94 @@ export class HypercertOperationsImpl extends EventEmitter<HypercertEvents> imple
       if (error instanceof ValidationError || error instanceof NetworkError) throw error;
       throw new NetworkError(`Failed to add evidence: ${error instanceof Error ? error.message : "Unknown"}`, error);
     }
+  }
+
+  /**
+   * Processes location parameters, creating a location record if necessary.
+   *
+   * @param locationParams - Location parameters from create request
+   * @param onProgress - Optional progress callback
+   * @returns Promise resolving to location StrongRef or undefined
+   * @internal
+   */
+  private async processLocation(
+    locationParams: LocationParams | undefined,
+    onProgress?: (step: ProgressStep) => void,
+  ): Promise<{ uri: string; cid: string } | undefined> {
+    if (!locationParams) return undefined;
+
+    try {
+      this.emitProgress(onProgress, { name: "createLocation", status: "start" });
+      const locationRef = await this.resolveLocation(locationParams);
+      this.emitProgress(onProgress, {
+        name: "createLocation",
+        status: "success",
+        data: { uri: locationRef.uri },
+      });
+      return locationRef;
+    } catch (error) {
+      this.emitProgress(onProgress, { name: "createLocation", status: "error", error: error as Error });
+      this.logger?.warn(`Failed to create location: ${error instanceof Error ? error.message : "Unknown"}`);
+      // Re-throw to fail the operation - swallowing would change rKey on retry
+      throw error;
+    }
+  }
+
+  /**
+   * Processes contribution parameters, creating detailed contribution records if necessary.
+   *
+   * @param contributions - Array of contribution parameters
+   * @param onProgress - Optional progress callback
+   * @returns Promise resolving to flattened array of contributor data for embedding
+   * @internal
+   */
+  private async processContributors(
+    contributions:
+      | Array<{ contributors: string[]; role: string; description?: string; props?: Record<string, unknown> }>
+      | undefined,
+    onProgress?: (step: ProgressStep) => void,
+  ): Promise<
+    Array<{ contributorIdentity: string; contributionDetails?: string | { uri: string; cid: string } }> | undefined
+  > {
+    if (!contributions || contributions.length === 0) return undefined;
+
+    const contributorsPromises = contributions.map(async (contrib) => {
+      let detailsRef: string | { uri: string; cid: string } = contrib.role;
+
+      // If description is provided, create a detailed record
+      if (contrib.description) {
+        try {
+          this.emitProgress(onProgress, { name: "createContribution", status: "start" });
+          const result = await this.addContribution({
+            contributors: contrib.contributors, // Passed for legacy reasons/completeness
+            role: contrib.role,
+            description: contrib.description,
+          });
+          detailsRef = { uri: result.uri, cid: result.cid };
+          this.emitProgress(onProgress, {
+            name: "createContribution",
+            status: "success",
+            data: result,
+          });
+        } catch (error) {
+          this.emitProgress(onProgress, {
+            name: "createContribution",
+            status: "error",
+            error: error as Error,
+          });
+          throw error;
+        }
+      }
+
+      // Expand to one entry per contributor DID
+      return contrib.contributors.map((did) => ({
+        contributorIdentity: did,
+        contributionDetails: detailsRef,
+      }));
+    });
+
+    const nestedContributors = await Promise.all(contributorsPromises);
+    return nestedContributors.flat();
   }
 
   /**

--- a/packages/sdk-core/src/repository/HypercertOperationsImpl.ts
+++ b/packages/sdk-core/src/repository/HypercertOperationsImpl.ts
@@ -323,8 +323,10 @@ export class HypercertOperationsImpl extends EventEmitter<HypercertEvents> imple
     }
 
     // Generate rKey from stable content hash (idempotency)
-    // Hash the complete claim record including all StrongRefs and embedded data
-    // These define the claim's identity per the lexicon.
+    // Use NORMALIZED values (already resolved StrongRefs and processed data)
+    // to ensure JSON-serializability and deterministic hashing.
+    // Raw params.location can contain non-serializable Blobs (GeoJSON),
+    // and params.contributions can have arbitrary/inconsistent props.
     const hashInput = {
       title: params.title,
       description: params.description,
@@ -332,14 +334,25 @@ export class HypercertOperationsImpl extends EventEmitter<HypercertEvents> imple
       workScope: params.workScope,
       startDate: params.startDate,
       endDate: params.endDate,
-      // Image blob reference (CID-based, stable)
-      imageRecord: imageBlobRef,
-      // Rights definition (what the user specified, not the generated CID)
-      rightsData: typeof params.rights === "object" ? params.rights : undefined,
-      // Location StrongRef - part of claim identity per lexicon
-      location: params.location,
-      // Contributors - part of claim identity per lexicon
-      contributors: params.contributions ? params.contributions : undefined,
+      // Image: extract CID string from blob ref (stable content hash)
+      // JsonBlobRef can have ref.$link (upload result) or cid (existing record)
+      imageRef: imageBlobRef
+        ? "ref" in imageBlobRef && imageBlobRef.ref
+          ? imageBlobRef.ref.$link
+          : "cid" in imageBlobRef
+            ? imageBlobRef.cid
+            : undefined
+        : undefined,
+      // Rights: canonical object with only known fields
+      rights: {
+        name: params.rights.name,
+        type: params.rights.type,
+        description: params.rights.description,
+      },
+      // Location: use resolved StrongRef (uri+cid), not raw params which may be Blob
+      locationRef: locationRef ? { uri: locationRef.uri, cid: locationRef.cid } : undefined,
+      // Contributors: use already-processed canonical format from processContributors()
+      contributors: contributorsData,
     };
 
     const contentHash = await sha256Hash(hashInput);

--- a/packages/sdk-core/src/repository/HypercertOperationsImpl.ts
+++ b/packages/sdk-core/src/repository/HypercertOperationsImpl.ts
@@ -252,6 +252,8 @@ export class HypercertOperationsImpl extends EventEmitter<HypercertEvents> imple
    * @param rightsUri - URI of the associated rights record
    * @param rightsCid - CID of the associated rights record
    * @param imageBlobRef - Optional image blob reference
+   * @param locationRef - Optional strong reference to the associated location record
+   * @param contributorsData - Optional array of contributor data (inline or StrongRef) to embed in the claim
    * @param createdAt - ISO timestamp for creation
    * @param onProgress - Optional progress callback
    * @returns Promise resolving to hypercert URI and CID

--- a/packages/sdk-core/src/repository/HypercertOperationsImpl.ts
+++ b/packages/sdk-core/src/repository/HypercertOperationsImpl.ts
@@ -545,6 +545,7 @@ export class HypercertOperationsImpl extends EventEmitter<HypercertEvents> imple
       const imageBlobRef = params.image ? await this.uploadImageBlob(params.image, params.onProgress) : undefined;
 
       // Step 2: Create location record if provided (must be before hypercert)
+      // If location is provided, it must succeed - failing silently would change the rKey on retries
       let locationRef: { uri: string; cid: string } | undefined;
       if (params.location) {
         try {
@@ -560,7 +561,8 @@ export class HypercertOperationsImpl extends EventEmitter<HypercertEvents> imple
         } catch (error) {
           this.emitProgress(params.onProgress, { name: "createLocation", status: "error", error: error as Error });
           this.logger?.warn(`Failed to create location: ${error instanceof Error ? error.message : "Unknown"}`);
-          // Don't throw - continue without location
+          // Re-throw to fail the operation - swallowing would change rKey on retry
+          throw error;
         }
       }
 

--- a/packages/sdk-core/src/repository/HypercertOperationsImpl.ts
+++ b/packages/sdk-core/src/repository/HypercertOperationsImpl.ts
@@ -264,6 +264,7 @@ export class HypercertOperationsImpl extends EventEmitter<HypercertEvents> imple
     rightsUri: string,
     rightsCid: string,
     imageBlobRef: JsonBlobRef | undefined,
+    locationRef: { uri: string; cid: string } | undefined,
     createdAt: string,
     onProgress?: (step: ProgressStep) => void,
   ): Promise<{ uri: string; cid: string }> {
@@ -284,6 +285,11 @@ export class HypercertOperationsImpl extends EventEmitter<HypercertEvents> imple
       hypercertRecord.image = imageBlobRef;
     }
 
+    // Add location as embedded StrongRef if provided
+    if (locationRef) {
+      hypercertRecord.locations = [{ uri: locationRef.uri, cid: locationRef.cid }];
+    }
+
     if (params.shortDescriptionFacets) {
       hypercertRecord.shortDescriptionFacets = params.shortDescriptionFacets;
     }
@@ -298,8 +304,8 @@ export class HypercertOperationsImpl extends EventEmitter<HypercertEvents> imple
     }
 
     // Generate rKey from stable content hash (idempotency)
-    // Hash only the fields that end up in the claim record itself, plus image blob ref and rights data.
-    // Excludes sidecar data (location, contributions, evidence) to keep rKeys stable.
+    // Hash the complete claim record including all StrongRefs (rights, location)
+    // These define the claim's identity per the lexicon.
     const hashInput = {
       title: params.title,
       description: params.description,
@@ -307,10 +313,12 @@ export class HypercertOperationsImpl extends EventEmitter<HypercertEvents> imple
       workScope: params.workScope,
       startDate: params.startDate,
       endDate: params.endDate,
-      // Use the full image blob reference for identity (handled by stable stringify)
+      // Image blob reference (CID-based, stable)
       imageRecord: imageBlobRef,
-      // Ensure rights definition is part of identity, but not the new CID
+      // Rights definition (what the user specified, not the generated CID)
       rightsData: typeof params.rights === "object" ? params.rights : undefined,
+      // Location StrongRef - part of claim identity per lexicon
+      locationRef: locationRef,
     };
 
     const contentHash = await sha256Hash(hashInput);
@@ -525,7 +533,27 @@ export class HypercertOperationsImpl extends EventEmitter<HypercertEvents> imple
       // Step 1: Upload image if provided
       const imageBlobRef = params.image ? await this.uploadImageBlob(params.image, params.onProgress) : undefined;
 
-      // Step 2: Create rights record
+      // Step 2: Create location record if provided (must be before hypercert)
+      let locationRef: { uri: string; cid: string } | undefined;
+      if (params.location) {
+        try {
+          this.emitProgress(params.onProgress, { name: "createLocation", status: "start" });
+          locationRef = await this.resolveLocation(params.location);
+          result.locationUri = locationRef.uri;
+          result.locationCid = locationRef.cid;
+          this.emitProgress(params.onProgress, {
+            name: "createLocation",
+            status: "success",
+            data: { uri: locationRef.uri },
+          });
+        } catch (error) {
+          this.emitProgress(params.onProgress, { name: "createLocation", status: "error", error: error as Error });
+          this.logger?.warn(`Failed to create location: ${error instanceof Error ? error.message : "Unknown"}`);
+          // Don't throw - continue without location
+        }
+      }
+
+      // Step 3: Create rights record
       const { uri: rightsUri, cid: rightsCid } = await this.createRightsRecord(
         params.rights,
         createdAt,
@@ -534,28 +562,18 @@ export class HypercertOperationsImpl extends EventEmitter<HypercertEvents> imple
       result.rightsUri = rightsUri;
       result.rightsCid = rightsCid;
 
-      // Step 3: Create hypercert record
+      // Step 4: Create hypercert record (with embedded location and rights StrongRefs)
       const { uri: hypercertUri, cid: hypercertCid } = await this.createHypercertRecord(
         params,
         rightsUri,
         rightsCid,
         imageBlobRef,
+        locationRef,
         createdAt,
         params.onProgress,
       );
       result.hypercertUri = hypercertUri;
       result.hypercertCid = hypercertCid;
-
-      // Step 4: Attach location if provided
-      if (params.location) {
-        try {
-          const { uri, cid } = await this.attachLocationWithProgress(hypercertUri, params.location, params.onProgress);
-          result.locationUri = uri;
-          result.locationCid = cid;
-        } catch {
-          // Error already logged and progress emitted
-        }
-      }
 
       // Step 5: Create contributions if provided
       if (params.contributions && params.contributions.length > 0) {

--- a/packages/sdk-core/src/repository/HypercertOperationsImpl.ts
+++ b/packages/sdk-core/src/repository/HypercertOperationsImpl.ts
@@ -337,9 +337,9 @@ export class HypercertOperationsImpl extends EventEmitter<HypercertEvents> imple
       // Rights definition (what the user specified, not the generated CID)
       rightsData: typeof params.rights === "object" ? params.rights : undefined,
       // Location StrongRef - part of claim identity per lexicon
-      locationRef: locationRef,
+      location: params.location,
       // Contributors - part of claim identity per lexicon
-      contributors: contributorsData,
+      contributors: params.contributions ? params.contributions : undefined,
     };
 
     const contentHash = await sha256Hash(hashInput);

--- a/packages/sdk-core/src/repository/HypercertOperationsImpl.ts
+++ b/packages/sdk-core/src/repository/HypercertOperationsImpl.ts
@@ -252,7 +252,7 @@ export class HypercertOperationsImpl extends EventEmitter<HypercertEvents> imple
    * @param rightsUri - URI of the associated rights record
    * @param rightsCid - CID of the associated rights record
    * @param imageBlobRef - Optional image blob reference
-   * @param locationRef - Optional strong reference to the associated location record
+   * @param locationRefs - Optional array of strong references to the associated location records
    * @param contributorsData - Optional array of contributor data (inline or StrongRef) to embed in the claim
    * @param createdAt - ISO timestamp for creation
    * @param onProgress - Optional progress callback
@@ -266,7 +266,7 @@ export class HypercertOperationsImpl extends EventEmitter<HypercertEvents> imple
     rightsUri: string,
     rightsCid: string,
     imageBlobRef: JsonBlobRef | undefined,
-    locationRef: { uri: string; cid: string } | undefined,
+    locationRefs: Array<{ uri: string; cid: string }> | undefined,
     contributorsData:
       | Array<{ contributorIdentity: string; contributionDetails?: string | { uri: string; cid: string } }>
       | undefined,
@@ -290,9 +290,9 @@ export class HypercertOperationsImpl extends EventEmitter<HypercertEvents> imple
       hypercertRecord.image = imageBlobRef;
     }
 
-    // Add location as embedded StrongRef if provided
-    if (locationRef) {
-      hypercertRecord.locations = [{ uri: locationRef.uri, cid: locationRef.cid }];
+    // Add locations as embedded StrongRefs if provided
+    if (locationRefs && locationRefs.length > 0) {
+      hypercertRecord.locations = locationRefs.map((ref) => ({ uri: ref.uri, cid: ref.cid }));
     }
 
     if (params.shortDescriptionFacets) {
@@ -349,8 +349,8 @@ export class HypercertOperationsImpl extends EventEmitter<HypercertEvents> imple
         type: params.rights.type,
         description: params.rights.description,
       },
-      // Location: use resolved StrongRef (uri+cid), not raw params which may be Blob
-      locationRef: locationRef ? { uri: locationRef.uri, cid: locationRef.cid } : undefined,
+      // Locations: use resolved StrongRefs (uri+cid), not raw params which may be Blob
+      locationRefs: locationRefs?.map((ref) => ({ uri: ref.uri, cid: ref.cid })),
       // Contributors: use already-processed canonical format from processContributors()
       contributors: contributorsData,
     };
@@ -522,9 +522,10 @@ export class HypercertOperationsImpl extends EventEmitter<HypercertEvents> imple
    * const result = await repo.hypercerts.create({
    *   title: "My Impact",
    *   description: "Description of impact work",
+   *   shortDescription: "Impact work",
    *   workScope: "Education",
-   *   workTimeframeFrom: "2024-01-01",
-   *   workTimeframeTo: "2024-06-30",
+   *   startDate: "2024-01-01",
+   *   endDate: "2024-06-30",
    *   rights: {
    *     name: "Attribution",
    *     type: "license",
@@ -540,11 +541,11 @@ export class HypercertOperationsImpl extends EventEmitter<HypercertEvents> imple
    *   description: "Planted 10,000 trees...",
    *   shortDescription: "10K trees planted",
    *   workScope: "Environment",
-   *   workTimeframeFrom: "2024-01-01",
-   *   workTimeframeTo: "2024-12-31",
+   *   startDate: "2024-01-01",
+   *   endDate: "2024-12-31",
    *   rights: { name: "Open", type: "impact", description: "..." },
    *   image: coverImageBlob,
-   *   location: { value: "Amazon, Brazil", name: "Amazon Basin" },
+   *   locations: [{ value: "Amazon, Brazil", name: "Amazon Basin" }],
    *   contributions: [
    *     { contributors: ["did:plc:org1"], role: "coordinator" },
    *     { contributors: ["did:plc:org2"], role: "implementer" },
@@ -567,12 +568,12 @@ export class HypercertOperationsImpl extends EventEmitter<HypercertEvents> imple
       // Step 1: Upload image if provided
       const imageBlobRef = params.image ? await this.uploadImageBlob(params.image, params.onProgress) : undefined;
 
-      // Step 2: Create location record if provided (must be before hypercert)
-      // If location is provided, it must succeed - failing silently would change the rKey on retries
-      const locationRef = await this.processLocation(params.location, params.onProgress);
-      if (locationRef) {
-        result.locationUri = locationRef.uri;
-        result.locationCid = locationRef.cid;
+      // Step 2: Create location records if provided (must be before hypercert)
+      // If locations are provided, they must succeed - failing silently would change the rKey on retries
+      const locationRefs = await this.processLocations(params.locations, params.onProgress);
+      if (locationRefs && locationRefs.length > 0) {
+        result.locationUris = locationRefs.map((ref) => ref.uri);
+        result.locationCids = locationRefs.map((ref) => ref.cid);
       }
 
       // Step 3: Create rights record
@@ -587,13 +588,13 @@ export class HypercertOperationsImpl extends EventEmitter<HypercertEvents> imple
       // Step 4: Build contributors data for embedding (if provided)
       const contributorsData = await this.processContributors(params.contributions, params.onProgress);
 
-      // Step 5: Create hypercert record (with embedded location, rights, and contributors)
+      // Step 5: Create hypercert record (with embedded locations, rights, and contributors)
       const { uri: hypercertUri, cid: hypercertCid } = await this.createHypercertRecord(
         params,
         rightsUri,
         rightsCid,
         imageBlobRef,
-        locationRef,
+        locationRefs,
         contributorsData,
         createdAt,
         params.onProgress,
@@ -914,18 +915,25 @@ export class HypercertOperationsImpl extends EventEmitter<HypercertEvents> imple
    */
   async attachLocation(hypercertUri: string, location: LocationParams): Promise<CreateResult> {
     try {
-      // Validate that hypercert exists (unused but confirms hypercert is valid)
-      await this.get(hypercertUri);
+      // Get existing hypercert to preserve current locations
+      const existing = await this.get(hypercertUri);
       const resolvedLocation = await this.resolveLocation(location);
+
+      // Build new locations array: existing + new location
+      const existingLocations = existing.record.locations || [];
+      const newLocations = [
+        ...existingLocations,
+        {
+          $type: "com.atproto.repo.strongRef",
+          uri: resolvedLocation.uri,
+          cid: resolvedLocation.cid,
+        } as StrongRef,
+      ];
 
       await this.update({
         uri: hypercertUri,
         updates: {
-          location: {
-            $type: "com.atproto.repo.strongRef",
-            uri: resolvedLocation.uri,
-            cid: resolvedLocation.cid,
-          },
+          locations: newLocations,
         },
       });
 
@@ -1108,28 +1116,28 @@ export class HypercertOperationsImpl extends EventEmitter<HypercertEvents> imple
   }
 
   /**
-   * Processes location parameters, creating a location record if necessary.
+   * Processes location parameters, creating location records if necessary.
    *
-   * @param locationParams - Location parameters from create request
+   * @param locationParams - Location parameters array from create request
    * @param onProgress - Optional progress callback
-   * @returns Promise resolving to location StrongRef or undefined
+   * @returns Promise resolving to array of location StrongRefs or undefined
    * @internal
    */
-  private async processLocation(
-    locationParams: LocationParams | undefined,
+  private async processLocations(
+    locationParams: LocationParams[] | undefined,
     onProgress?: (step: ProgressStep) => void,
-  ): Promise<{ uri: string; cid: string } | undefined> {
-    if (!locationParams) return undefined;
+  ): Promise<Array<{ uri: string; cid: string }> | undefined> {
+    if (!locationParams || locationParams.length === 0) return undefined;
 
     try {
       this.emitProgress(onProgress, { name: "createLocation", status: "start" });
-      const locationRef = await this.resolveLocation(locationParams);
+      const locationRefs = await Promise.all(locationParams.map((loc) => this.resolveLocation(loc)));
       this.emitProgress(onProgress, {
         name: "createLocation",
         status: "success",
-        data: { uri: locationRef.uri },
+        data: { count: locationRefs.length },
       });
-      return locationRef;
+      return locationRefs;
     } catch (error) {
       this.emitProgress(onProgress, { name: "createLocation", status: "error", error: error as Error });
       this.logger?.warn(`Failed to create location: ${error instanceof Error ? error.message : "Unknown"}`);

--- a/packages/sdk-core/src/repository/interfaces.ts
+++ b/packages/sdk-core/src/repository/interfaces.ts
@@ -51,9 +51,10 @@ export type { LocationParams };
  * const params: CreateHypercertParams = {
  *   title: "Community Garden Project",
  *   description: "Established a 1-acre community garden serving 50 families",
+ *   shortDescription: "1-acre community garden",
  *   workScope: "Food Security",
- *   workTimeframeFrom: "2024-01-01",
- *   workTimeframeTo: "2024-06-30",
+ *   startDate: "2024-01-01",
+ *   endDate: "2024-06-30",
  *   rights: {
  *     name: "Attribution",
  *     type: "license",
@@ -69,19 +70,21 @@ export type { LocationParams };
  *   description: "Planted 10,000 trees in deforested areas",
  *   shortDescription: "10K trees planted",
  *   workScope: "Environmental Restoration",
- *   workTimeframeFrom: "2024-01-01",
- *   workTimeframeTo: "2024-12-31",
+ *   startDate: "2024-01-01",
+ *   endDate: "2024-12-31",
  *   rights: {
  *     name: "Open Impact",
  *     type: "impact-rights",
  *     description: "Transferable impact rights",
  *   },
  *   image: coverImageBlob,
- *   location: {
- *     value: "Amazon Rainforest, Brazil",
- *     name: "Amazon Basin",
- *     description: "Southern Amazon region",
- *   },
+ *   locations: [
+ *     {
+ *       value: "Amazon Rainforest, Brazil",
+ *       name: "Amazon Basin",
+ *       description: "Southern Amazon region",
+ *     },
+ *   ],
  *   contributions: [
  *     {
  *       contributors: ["did:plc:lead-org"],
@@ -225,9 +228,12 @@ export interface CreateHypercertParams {
   image?: Blob;
 
   /**
-   * Optional geographic location of the impact.
+   * Optional geographic locations of the impact.
+   *
+   * Can provide multiple locations for activities spanning multiple places.
+   * Each location can be a StrongRef, string URI, or location object.
    */
-  location?: LocationParams;
+  locations?: LocationParams[];
 
   /**
    * Optional list of contributions to the impact.
@@ -356,14 +362,14 @@ export interface CreateHypercertResult {
   rightsCid: string;
 
   /**
-   * AT-URI of the location record, if location was provided.
+   * AT-URIs of location records, if locations were provided.
    */
-  locationUri?: string;
+  locationUris?: string[];
 
   /**
-   * CID of the location record
+   * CIDs of location records, if locations were provided.
    */
-  locationCid?: string;
+  locationCids?: string[];
 
   /**
    * AT-URIs of contribution records, if contributions were provided.

--- a/packages/sdk-core/tests/lib/crypto.test.ts
+++ b/packages/sdk-core/tests/lib/crypto.test.ts
@@ -64,3 +64,19 @@ describe("stableStringify", () => {
         expect(stableStringify(obj)).toBe('{"id":1,"meta":{"info":{"x":1,"y":2},"tags":["b","a"]}}');
     });
 });
+
+import { sha256Hash } from "../../src/lib/crypto.js";
+import { ValidationError } from "../../src/core/errors.js";
+
+describe("sha256Hash", () => {
+    it("should throw ValidationError for undefined input", async () => {
+        await expect(sha256Hash(undefined)).rejects.toThrow(ValidationError);
+        await expect(sha256Hash(undefined)).rejects.toThrow(/Content illegal: not serializable/);
+    });
+
+    it("should throw ValidationError for function input", async () => {
+        const func = () => { };
+        await expect(sha256Hash(func)).rejects.toThrow(ValidationError);
+        await expect(sha256Hash(func)).rejects.toThrow(/Content illegal: not serializable/);
+    });
+});

--- a/packages/sdk-core/tests/lib/crypto.test.ts
+++ b/packages/sdk-core/tests/lib/crypto.test.ts
@@ -1,0 +1,66 @@
+
+import { describe, it, expect } from "vitest";
+import { stableStringify } from "../../src/lib/crypto.js";
+
+describe("stableStringify", () => {
+    it("should stringify primitives", () => {
+        expect(stableStringify(1)).toBe("1");
+        expect(stableStringify("test")).toBe('"test"');
+        expect(stableStringify(true)).toBe("true");
+        expect(stableStringify(null)).toBe("null");
+    });
+
+    it("should sort object keys", () => {
+        const obj = { c: 3, a: 1, b: 2 };
+        expect(stableStringify(obj)).toBe('{"a":1,"b":2,"c":3}');
+    });
+
+    it("should sort nested object keys", () => {
+        const obj = {
+            z: { y: 2, x: 1 },
+            a: { c: 3, b: 4 },
+        };
+        expect(stableStringify(obj)).toBe('{"a":{"b":4,"c":3},"z":{"x":1,"y":2}}');
+    });
+
+    it("should preserve array order", () => {
+        const arr = [3, 1, 2];
+        expect(stableStringify(arr)).toBe("[3,1,2]");
+    });
+
+    it("should sort objects inside arrays", () => {
+        const arr = [
+            { b: 2, a: 1 },
+            { d: 4, c: 3 },
+        ];
+        expect(stableStringify(arr)).toBe('[{"a":1,"b":2},{"c":3,"d":4}]');
+    });
+
+    it("should ignore undefined, functions, and symbols", () => {
+        const obj = {
+            a: 1,
+            b: undefined,
+            c: () => { },
+            d: Symbol("test"),
+            e: 2,
+        };
+        expect(stableStringify(obj)).toBe('{"a":1,"e":2}');
+    });
+
+    it("should return undefined for non-serializable top-level inputs", () => {
+        expect(stableStringify(undefined)).toBeUndefined();
+        expect(stableStringify(() => { })).toBeUndefined();
+        expect(stableStringify(Symbol("test"))).toBeUndefined();
+    });
+
+    it("should handle mixed complex structures", () => {
+        const obj = {
+            id: 1,
+            meta: {
+                tags: ["b", "a"], // Array order preserved
+                info: { y: 2, x: 1 } // Object keys sorted
+            }
+        };
+        expect(stableStringify(obj)).toBe('{"id":1,"meta":{"info":{"x":1,"y":2},"tags":["b","a"]}}');
+    });
+});

--- a/packages/sdk-core/tests/repository/HypercertOperationsImpl.test.ts
+++ b/packages/sdk-core/tests/repository/HypercertOperationsImpl.test.ts
@@ -230,6 +230,7 @@ describe("HypercertOperationsImpl", () => {
     });
 
     it("should create contributions when provided", async () => {
+      // Contributors are now embedded in the claim record, not created as separate records
       mockAgent.com.atproto.repo.createRecord.mockReset();
       mockAgent.com.atproto.repo.createRecord
         .mockResolvedValueOnce({
@@ -239,34 +240,21 @@ describe("HypercertOperationsImpl", () => {
         .mockResolvedValueOnce({
           success: true,
           data: { uri: "at://did:plc:test/org.hypercerts.claim.record/def", cid: "hypercert-cid" },
-        })
-        .mockResolvedValueOnce({
-          success: true,
-          data: { uri: "at://did:plc:test/org.hypercerts.claim.contribution/contrib1", cid: "contrib-cid" },
         });
-
-      mockAgent.com.atproto.repo.getRecord.mockResolvedValue({
-        success: true,
-        data: {
-          uri: "at://did:plc:test/org.hypercerts.claim.record/def",
-          cid: "hypercert-cid",
-          value: {
-            title: "Test",
-            description: "Test",
-            workScope: createWorkScopeAll(["Climate"]),
-            startDate: "2024-01-01",
-            endDate: "2024-12-31",
-            createdAt: "2024-01-01",
-          },
-        },
-      });
 
       const result = await hypercertOps.create({
         ...validParams,
         contributions: [{ contributors: ["did:plc:contrib1"], role: "Developer" }],
       });
 
-      expect(result.contributionUris).toHaveLength(1);
+      expect(result.hypercertUri).toBeDefined();
+
+      // Verify contributors are embedded in the claim record
+      const createCall = mockAgent.com.atproto.repo.createRecord.mock.calls[1][0];
+      expect(createCall.record.contributors).toBeDefined();
+      expect(createCall.record.contributors).toHaveLength(1);
+      expect(createCall.record.contributors[0].contributorIdentity).toBe("did:plc:contrib1");
+      expect(createCall.record.contributors[0].contributionDetails).toBe("Developer");
     });
 
     it("should call onProgress callback", async () => {

--- a/packages/sdk-core/tests/repository/HypercertOperationsImpl.test.ts
+++ b/packages/sdk-core/tests/repository/HypercertOperationsImpl.test.ts
@@ -197,9 +197,13 @@ describe("HypercertOperationsImpl", () => {
     });
 
     it("should attach location when provided", async () => {
-      // Reset mocks and set up for location
+      // Reset mocks and set up for location (new order: location → rights → hypercert)
       mockAgent.com.atproto.repo.createRecord.mockReset();
       mockAgent.com.atproto.repo.createRecord
+        .mockResolvedValueOnce({
+          success: true,
+          data: { uri: "at://did:plc:test/app.certified.location/ghi", cid: "location-cid" },
+        })
         .mockResolvedValueOnce({
           success: true,
           data: { uri: "at://did:plc:test/org.hypercerts.claim.rights/abc", cid: "rights-cid" },
@@ -207,34 +211,7 @@ describe("HypercertOperationsImpl", () => {
         .mockResolvedValueOnce({
           success: true,
           data: { uri: "at://did:plc:test/org.hypercerts.claim.record/def", cid: "hypercert-cid" },
-        })
-        .mockResolvedValueOnce({
-          success: true,
-          data: { uri: "at://did:plc:test/app.certified.location/ghi", cid: "location-cid" },
         });
-
-      // Mock getRecord for attachLocation's internal get call
-      mockAgent.com.atproto.repo.getRecord.mockResolvedValue({
-        success: true,
-        data: {
-          uri: "at://did:plc:test/org.hypercerts.claim.record/def",
-          cid: "hypercert-cid",
-          value: {
-            title: "Test",
-            description: "Test",
-            workScope: createWorkScopeAll(["Climate"]),
-            startDate: "2024-01-01",
-            endDate: "2024-12-31",
-            createdAt: "2024-01-01",
-          },
-        },
-      });
-
-      // Mock putRecord for the update call
-      mockAgent.com.atproto.repo.putRecord.mockResolvedValue({
-        success: true,
-        data: { uri: "at://did:plc:test/org.hypercerts.claim.record/def", cid: "updated-cid" },
-      });
 
       const result = await hypercertOps.create({
         ...validParams,

--- a/packages/sdk-core/tests/repository/HypercertOperationsImpl.test.ts
+++ b/packages/sdk-core/tests/repository/HypercertOperationsImpl.test.ts
@@ -215,18 +215,80 @@ describe("HypercertOperationsImpl", () => {
 
       const result = await hypercertOps.create({
         ...validParams,
-        location: {
-          lpVersion: "1.0.0",
-          srs: "EPSG:4326",
-          locationType: "coordinate-decimal",
-          location: "https://example.com/location",
-          name: "Test Location",
-          description: "A test location",
-        },
+        locations: [
+          {
+            lpVersion: "1.0.0",
+            srs: "EPSG:4326",
+            locationType: "coordinate-decimal",
+            location: "https://example.com/location",
+            name: "Test Location",
+            description: "A test location",
+          },
+        ],
       });
 
-      expect(result.locationUri).toEqual("at://did:plc:test/app.certified.location/ghi");
-      expect(result.locationCid).toEqual("location-cid");
+      expect(result.locationUris).toEqual(["at://did:plc:test/app.certified.location/ghi"]);
+      expect(result.locationCids).toEqual(["location-cid"]);
+    });
+
+    it("should attach multiple locations when provided", async () => {
+      // Reset mocks and set up for multiple locations (location1 → location2 → rights → hypercert)
+      mockAgent.com.atproto.repo.createRecord.mockReset();
+      mockAgent.com.atproto.repo.createRecord
+        .mockResolvedValueOnce({
+          success: true,
+          data: { uri: "at://did:plc:test/app.certified.location/loc1", cid: "location-cid-1" },
+        })
+        .mockResolvedValueOnce({
+          success: true,
+          data: { uri: "at://did:plc:test/app.certified.location/loc2", cid: "location-cid-2" },
+        })
+        .mockResolvedValueOnce({
+          success: true,
+          data: { uri: "at://did:plc:test/org.hypercerts.claim.rights/abc", cid: "rights-cid" },
+        })
+        .mockResolvedValueOnce({
+          success: true,
+          data: { uri: "at://did:plc:test/org.hypercerts.claim.record/def", cid: "hypercert-cid" },
+        });
+
+      const result = await hypercertOps.create({
+        ...validParams,
+        locations: [
+          {
+            lpVersion: "1.0.0",
+            srs: "EPSG:4326",
+            locationType: "coordinate-decimal",
+            location: "https://example.com/location1",
+            name: "Location 1",
+          },
+          {
+            lpVersion: "1.0.0",
+            srs: "EPSG:4326",
+            locationType: "coordinate-decimal",
+            location: "https://example.com/location2",
+            name: "Location 2",
+          },
+        ],
+      });
+
+      expect(result.locationUris).toEqual([
+        "at://did:plc:test/app.certified.location/loc1",
+        "at://did:plc:test/app.certified.location/loc2",
+      ]);
+      expect(result.locationCids).toEqual(["location-cid-1", "location-cid-2"]);
+
+      // Verify the hypercert record has both locations embedded
+      const hypercertCall = mockAgent.com.atproto.repo.createRecord.mock.calls[3][0];
+      expect(hypercertCall.record.locations).toHaveLength(2);
+      expect(hypercertCall.record.locations[0]).toEqual({
+        uri: "at://did:plc:test/app.certified.location/loc1",
+        cid: "location-cid-1",
+      });
+      expect(hypercertCall.record.locations[1]).toEqual({
+        uri: "at://did:plc:test/app.certified.location/loc2",
+        cid: "location-cid-2",
+      });
     });
 
     it("should create contributions when provided", async () => {

--- a/packages/sdk-core/tests/repository/HypercertOperationsImpl.test.ts
+++ b/packages/sdk-core/tests/repository/HypercertOperationsImpl.test.ts
@@ -257,6 +257,45 @@ describe("HypercertOperationsImpl", () => {
       expect(createCall.record.contributors[0].contributionDetails).toBe("Developer");
     });
 
+    it("should create detailed contributions (StrongRef) when description is provided", async () => {
+      mockAgent.com.atproto.repo.createRecord.mockReset();
+      mockAgent.com.atproto.repo.createRecord
+        .mockResolvedValueOnce({
+          success: true,
+          data: { uri: "at://did:plc:test/org.hypercerts.claim.rights/abc", cid: "rights-cid" },
+        })
+        .mockResolvedValueOnce({
+          success: true,
+          data: { uri: "at://did:plc:test/org.hypercerts.claim.contributionDetails/xyz", cid: "details-cid" },
+        })
+        .mockResolvedValueOnce({
+          success: true,
+          data: { uri: "at://did:plc:test/org.hypercerts.claim.record/def", cid: "hypercert-cid" },
+        });
+
+      const result = await hypercertOps.create({
+        ...validParams,
+        contributions: [{ contributors: ["did:plc:contrib1"], role: "Developer", description: "Backend work" }],
+      });
+
+      expect(result.hypercertUri).toBeDefined();
+
+      // Verify contribution details record was created
+      const contributionCall = mockAgent.com.atproto.repo.createRecord.mock.calls[1][0];
+      expect(contributionCall.collection).toBe("org.hypercerts.claim.contributionDetails");
+      expect(contributionCall.record.role).toBe("Developer");
+      expect(contributionCall.record.contributionDescription).toBe("Backend work");
+
+      // Verify contributors use StrongRef in the claim record
+      const createCall = mockAgent.com.atproto.repo.createRecord.mock.calls[2][0];
+      expect(createCall.record.contributors).toBeDefined();
+      expect(createCall.record.contributors[0].contributorIdentity).toBe("did:plc:contrib1");
+      expect(createCall.record.contributors[0].contributionDetails).toEqual({
+        uri: "at://did:plc:test/org.hypercerts.claim.contributionDetails/xyz",
+        cid: "details-cid",
+      });
+    });
+
     it("should call onProgress callback", async () => {
       const onProgress = vi.fn();
 

--- a/packages/sdk-react/src/types.ts
+++ b/packages/sdk-react/src/types.ts
@@ -14,7 +14,7 @@ import type {
   CreateOrganizationParams,
   CreateProjectParams,
   HypercertClaim,
-  HypercertProjectWithMetadata,
+  HypercertProject,
   OrganizationInfo,
   OrgHypercertsDefs,
   Repository,
@@ -396,7 +396,7 @@ export interface UseHypercertResult {
 export type Project = {
   uri: string;
   cid: string;
-  record: HypercertProjectWithMetadata;
+  record: HypercertProject;
 };
 
 /**
@@ -502,7 +502,7 @@ export type {
   CreateOrganizationParams,
   CreateProjectParams,
   HypercertClaim,
-  HypercertProjectWithMetadata,
+  HypercertProject,
   OrganizationInfo,
   OrgHypercertsDefs,
   Repository,


### PR DESCRIPTION
# Feature: Deterministic rKey Generation for Activity Claims

Closes #102 
# Feature: Deterministic rKey Generation & Enhanced Contribution Support
### Deterministic rKeys
The SDK now pre-generates the `rKey` based on the SHA-256 hash of the complete claim content. 
Format: `hc2:{sha256Hash}`
### Detailed Contributions
Added support for the full `contributionDetails` union type in the lexicon.
- If a contribution has a definition (role only) -> embedded as inline string.
- If a contribution has details (description, etc) -> creates a `org.hypercerts.claim.contributionDetails` record and embeds the StrongRef.
## Motivation
- **Idempotency**: Ensures that creating the same claim twice results in the same Record Key.
- **Completeness**: The rKey hash now includes all referenced data (locations, rights, detailed contributions) ensuring correct identification.
- **Flexibility**: Users can now provide rich contribution data (descriptions) via the SDK.
## Changes
- **New Utility**: Added [src/lib/crypto.ts](file:///Users/sharfy/Code/hypercerts-sdk/packages/sdk-core/src/lib/crypto.ts) for consistent SHA-256 hashing.
- **Refactoring**: Updated `HypercertOperationsImpl.create` to:
  - Create and resolve `location` StrongRefs *before* the claim.
  - Create and resolve `contributionDetails` StrongRefs *before* the claim.
  - Embed these StrongRefs directly into the claim record.
  - Compute the rKey hash over this complete structure.
- **Testing**: Added tests for hashing and detailed contribution creation.
## Verification
- Ran `pnpm test` in `packages/sdk-core` -> All 618 tests passed.
- Verified `pnpm typecheck` passes.
- Confirmed backward compatibility with simple role-based contributions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Support for multiple locations per hypercert activity claim
  * New shortDescription field for hypercert creation
  * Deterministic rKey generation for activity claims

* **Bug Fixes**
  * Fixed location attachment to append instead of replace
  * Improved hash input normalization for stable rKey generation

* **Breaking Changes**
  * `location` parameter renamed to `locations` (array)
  * `locationUri`/`locationCid` renamed to `locationUris`/`locationCids` (arrays)

* **Documentation**
  * Updated README examples

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces multi-location claims and deterministic record keys, refactoring creation flow to embed normalized references for idempotency and consistency.
> 
> - Breaking: `CreateHypercertParams.location` → `CreateHypercertParams.locations[]`; `CreateHypercertResult.locationUri/Cid` → `locationUris/Cids`; `attachLocation()` now appends to `locations`
> - New: Pre-generate `rKey` as `hc2:{sha256}` using `src/lib/crypto.ts` (`stableStringify`, `sha256Hash`) over normalized inputs (image CID, rights, `locations` StrongRefs, contributors data)
> - Create flow: resolve `locations` and contribution details first, then create rights and the claim with embedded `locations` and `contributors`
> - Tests: add hashing and operations tests; README examples updated to `startDate/endDate` and `locations`
> - React types: replace `HypercertProjectWithMetadata` with `HypercertProject` re-exports
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fb29a8911745eb6374ded37f34c34c1430e0256d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->