### PR TITLE
fix: preserve empty arrays in facet fields

### DIFF
--- a/packages/sdk-core/src/repository/HypercertOperationsImpl.ts
+++ b/packages/sdk-core/src/repository/HypercertOperationsImpl.ts
@@ -295,11 +295,11 @@ export class HypercertOperationsImpl extends EventEmitter<HypercertEvents> imple
       hypercertRecord.locations = locationRefs.map((ref) => ({ uri: ref.uri, cid: ref.cid }));
     }
 
-    if (params.shortDescriptionFacets) {
+    if (params.shortDescriptionFacets !== undefined) {
       hypercertRecord.shortDescriptionFacets = params.shortDescriptionFacets;
     }
 
-    if (params.descriptionFacets) {
+    if (params.descriptionFacets !== undefined) {
       hypercertRecord.descriptionFacets = params.descriptionFacets;
     }
 


### PR DESCRIPTION
Change truthy checks to explicit !== undefined checks for shortDescriptionFacets and descriptionFacets to ensure empty arrays are preserved as valid values.

Fixes unresolved comment from PR #112 review thread #3700691486

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed handling of description fields during record creation so explicitly provided falsy or null values for short description and description are now preserved instead of being ignored.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures facet fields are written even when empty arrays are provided.
> 
> - In `HypercertOperationsImpl.ts` `createHypercertRecord`, changed checks to `params.* !== undefined` for `shortDescriptionFacets` and `descriptionFacets`, allowing empty arrays to be persisted instead of being skipped.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e97a2838e98e6ae151c6f168a58262e9fde85676. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->