### PR TITLE
fix: migrate legacy location field to locations array

### DIFF
--- a/.changeset/wise-papayas-sing.md
+++ b/.changeset/wise-papayas-sing.md
@@ -3,3 +3,6 @@
 ---
 
 feat: implement pre-generation of rKeys for activity claims using deterministic content hashing (SHA-256).
+
+fix: normalize hashInput in `createHypercertRecord()` to use resolved StrongRefs (`locationRef`, `contributorsData`)
+instead of raw params which may contain non-serializable Blobs or inconsistent formats, ensuring stable rKey generation.

--- a/.changeset/wise-papayas-sing.md
+++ b/.changeset/wise-papayas-sing.md
@@ -1,0 +1,5 @@
+---
+"@hypercerts-org/sdk-core": minor
+---
+
+feat: implement pre-generation of rKeys for activity claims using deterministic content hashing (SHA-256).

--- a/.changeset/wise-rice-create.md
+++ b/.changeset/wise-rice-create.md
@@ -1,0 +1,6 @@
+---
+"@hypercerts-org/sdk-react": minor
+"@hypercerts-org/sdk-core": minor
+---
+
+fix: migrate legacy location field to locations array in attachLocation

--- a/packages/sdk-core/src/lib/crypto.ts
+++ b/packages/sdk-core/src/lib/crypto.ts
@@ -2,7 +2,7 @@
  * Crypto utilities for the SDK.
  */
 
-import { NetworkError } from "../core/errors.js";
+import { NetworkError, ValidationError } from "../core/errors.js";
 
 /**
  * Deterministically stringifies an object by sorting keys recursively.
@@ -43,10 +43,16 @@ export function stableStringify(obj: unknown): string | undefined {
  *
  * @param content - The content to hash (will be JSON serialized)
  * @returns The SHA-256 hash of the content
+ * @throws {ValidationError} If content is not serializable (e.g. undefined, function, symbol)
  */
 export async function sha256Hash(content: unknown): Promise<string> {
     // Use stable stringification to ensure deterministic output
-    const jsonString = stableStringify(content) ?? "";
+    const jsonString = stableStringify(content);
+
+    if (jsonString === undefined) {
+        throw new ValidationError(`Content illegal: not serializable (type: ${typeof content})`);
+    }
+
     const msgBuffer = new TextEncoder().encode(jsonString);
 
     if (typeof crypto !== "undefined" && crypto.subtle) {

--- a/packages/sdk-core/src/lib/crypto.ts
+++ b/packages/sdk-core/src/lib/crypto.ts
@@ -1,0 +1,69 @@
+/**
+ * Crypto utilities for the SDK.
+ */
+
+import { NetworkError } from "../core/errors.js";
+
+/**
+ * Deterministically stringifies an object by sorting keys recursively.
+ * Handles deeply nested objects and null values correctly.
+ */
+function stableStringify(obj: unknown): string | undefined {
+    if (obj === undefined || typeof obj === "function" || typeof obj === "symbol") {
+        return undefined;
+    }
+    if (obj === null || typeof obj !== "object") {
+        return JSON.stringify(obj);
+    }
+
+    if (Array.isArray(obj)) {
+        return JSON.stringify(obj.map((item) => {
+            const val = stableStringify(item);
+            return val === undefined ? null : JSON.parse(val);
+        }));
+    }
+
+    const sortedKeys = Object.keys(obj as object).sort();
+    const sortedObj: Record<string, unknown> = {};
+
+    for (const key of sortedKeys) {
+        const value = (obj as Record<string, unknown>)[key];
+        const str = stableStringify(value);
+        // Skip undefined or non-serializable values
+        if (str === undefined) continue;
+        sortedObj[key] = JSON.parse(str);
+    }
+
+    return JSON.stringify(sortedObj);
+}
+
+/**
+ * Computes the SHA-256 hash of a JSON-serializable object.
+ * Returns the hash as a hexadecimal string.
+ *
+ * @param content - The content to hash (will be JSON serialized)
+ * @returns The SHA-256 hash of the content
+ */
+export async function sha256Hash(content: unknown): Promise<string> {
+    // Use stable stringification to ensure deterministic output
+    const jsonString = stableStringify(content) ?? "";
+    const msgBuffer = new TextEncoder().encode(jsonString);
+
+    if (typeof crypto !== "undefined" && crypto.subtle) {
+        // Browser / Modern Node.js
+        const hashBuffer = await crypto.subtle.digest("SHA-256", msgBuffer);
+        const hashArray = Array.from(new Uint8Array(hashBuffer));
+        return hashArray.map((b) => b.toString(16).padStart(2, "0")).join("");
+    } else {
+        // Fallback for older environments or specific setups if global crypto isn't available
+        try {
+            // Dynamic import to avoid breaking browser builds if bundler doesn't handle it
+             
+            const { createHash } = await import("node:crypto");
+            const hash = createHash("sha256").update(jsonString).digest("hex");
+            return hash;
+        } catch (e) {
+            throw new NetworkError("SHA-256 hashing not supported in this environment", e);
+        }
+    }
+}

--- a/packages/sdk-core/src/lib/crypto.ts
+++ b/packages/sdk-core/src/lib/crypto.ts
@@ -8,7 +8,7 @@ import { NetworkError } from "../core/errors.js";
  * Deterministically stringifies an object by sorting keys recursively.
  * Handles deeply nested objects and null values correctly.
  */
-function stableStringify(obj: unknown): string | undefined {
+export function stableStringify(obj: unknown): string | undefined {
     if (obj === undefined || typeof obj === "function" || typeof obj === "symbol") {
         return undefined;
     }
@@ -58,7 +58,7 @@ export async function sha256Hash(content: unknown): Promise<string> {
         // Fallback for older environments or specific setups if global crypto isn't available
         try {
             // Dynamic import to avoid breaking browser builds if bundler doesn't handle it
-             
+
             const { createHash } = await import("node:crypto");
             const hash = createHash("sha256").update(jsonString).digest("hex");
             return hash;

--- a/packages/sdk-core/src/repository/HypercertOperationsImpl.ts
+++ b/packages/sdk-core/src/repository/HypercertOperationsImpl.ts
@@ -264,6 +264,7 @@ export class HypercertOperationsImpl extends EventEmitter<HypercertEvents> imple
     rightsUri: string,
     rightsCid: string,
     imageBlobRef: JsonBlobRef | undefined,
+    locationRef: { uri: string; cid: string } | undefined,
     createdAt: string,
     onProgress?: (step: ProgressStep) => void,
   ): Promise<{ uri: string; cid: string }> {
@@ -284,14 +285,19 @@ export class HypercertOperationsImpl extends EventEmitter<HypercertEvents> imple
       hypercertRecord.image = imageBlobRef;
     }
 
+    // Add location as embedded StrongRef if provided
+    if (locationRef) {
+      hypercertRecord.locations = [{ uri: locationRef.uri, cid: locationRef.cid }];
+    }
+
     const hypercertValidation = validate(hypercertRecord, HYPERCERT_COLLECTIONS.CLAIM, "main", false);
     if (!hypercertValidation.success) {
       throw new ValidationError(`Invalid hypercert record: ${hypercertValidation.error?.message}`);
     }
 
     // Generate rKey from stable content hash (idempotency)
-    // Hash only the fields that end up in the claim record itself, plus image blob ref and rights data.
-    // Excludes sidecar data (location, contributions, evidence) to keep rKeys stable.
+    // Hash the complete claim record including all StrongRefs (rights, location)
+    // These define the claim's identity per the lexicon.
     const hashInput = {
       title: params.title,
       description: params.description,
@@ -299,10 +305,12 @@ export class HypercertOperationsImpl extends EventEmitter<HypercertEvents> imple
       workScope: params.workScope,
       startDate: params.startDate,
       endDate: params.endDate,
-      // Use the full image blob reference for identity (handled by stable stringify)
+      // Image blob reference (CID-based, stable)
       imageRecord: imageBlobRef,
-      // Ensure rights definition is part of identity, but not the new CID
+      // Rights definition (what the user specified, not the generated CID)
       rightsData: typeof params.rights === "object" ? params.rights : undefined,
+      // Location StrongRef - part of claim identity per lexicon
+      locationRef: locationRef,
     };
 
     const contentHash = await sha256Hash(hashInput);
@@ -517,7 +525,26 @@ export class HypercertOperationsImpl extends EventEmitter<HypercertEvents> imple
       // Step 1: Upload image if provided
       const imageBlobRef = params.image ? await this.uploadImageBlob(params.image, params.onProgress) : undefined;
 
-      // Step 2: Create rights record
+      // Step 2: Create location record if provided (must be before hypercert)
+      let locationRef: { uri: string; cid: string } | undefined;
+      if (params.location) {
+        try {
+          this.emitProgress(params.onProgress, { name: "createLocation", status: "start" });
+          locationRef = await this.resolveLocation(params.location);
+          result.locationUri = locationRef.uri;
+          this.emitProgress(params.onProgress, {
+            name: "createLocation",
+            status: "success",
+            data: { uri: locationRef.uri },
+          });
+        } catch (error) {
+          this.emitProgress(params.onProgress, { name: "createLocation", status: "error", error: error as Error });
+          this.logger?.warn(`Failed to create location: ${error instanceof Error ? error.message : "Unknown"}`);
+          // Don't throw - continue without location
+        }
+      }
+
+      // Step 3: Create rights record
       const { uri: rightsUri, cid: rightsCid } = await this.createRightsRecord(
         params.rights,
         createdAt,
@@ -526,26 +553,18 @@ export class HypercertOperationsImpl extends EventEmitter<HypercertEvents> imple
       result.rightsUri = rightsUri;
       result.rightsCid = rightsCid;
 
-      // Step 3: Create hypercert record
+      // Step 4: Create hypercert record (with embedded location and rights StrongRefs)
       const { uri: hypercertUri, cid: hypercertCid } = await this.createHypercertRecord(
         params,
         rightsUri,
         rightsCid,
         imageBlobRef,
+        locationRef,
         createdAt,
         params.onProgress,
       );
       result.hypercertUri = hypercertUri;
       result.hypercertCid = hypercertCid;
-
-      // Step 4: Attach location if provided
-      if (params.location) {
-        try {
-          result.locationUri = await this.attachLocationWithProgress(hypercertUri, params.location, params.onProgress);
-        } catch {
-          // Error already logged and progress emitted
-        }
-      }
 
       // Step 5: Create contributions if provided
       if (params.contributions && params.contributions.length > 0) {

--- a/packages/sdk-core/src/repository/HypercertOperationsImpl.ts
+++ b/packages/sdk-core/src/repository/HypercertOperationsImpl.ts
@@ -44,6 +44,7 @@ import type {
 } from "./interfaces.js";
 import type { CreateResult, ListParams, PaginatedList, ProgressStep, UpdateResult } from "./types.js";
 import { $Typed } from "@atproto/api";
+import { sha256Hash } from "../lib/crypto.js";
 
 /**
  * Implementation of high-level hypercert operations.
@@ -288,10 +289,29 @@ export class HypercertOperationsImpl extends EventEmitter<HypercertEvents> imple
       throw new ValidationError(`Invalid hypercert record: ${hypercertValidation.error?.message}`);
     }
 
+    // Generate rKey from stable content hash (idempotency)
+    // We hash the user's intent (params + rights definition), not the volatile outputs (like new rights CID or createdAt)
+
+    // Destructure to remove non-hashable/redundant fields (image, onProgress)
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { image, onProgress: _onProgress, ...paramsForHash } = params;
+
+    const hashInput = {
+      ...paramsForHash,
+      // Use the full image blob reference for identity (handled by stable stringify)
+      imageRecord: imageBlobRef,
+      // Ensure rights definition is part of identity, but not the new CID
+      rightsData: typeof params.rights === "object" ? params.rights : undefined,
+    };
+
+    const contentHash = await sha256Hash(hashInput);
+    const rkey = `hc2:${contentHash}`;
+
     const hypercertResult = await this.agent.com.atproto.repo.createRecord({
       repo: this.repoDid,
       collection: HYPERCERT_COLLECTIONS.CLAIM,
       record: hypercertRecord,
+      rkey,
     });
 
     if (!hypercertResult.success) {

--- a/packages/sdk-core/src/repository/HypercertOperationsImpl.ts
+++ b/packages/sdk-core/src/repository/HypercertOperationsImpl.ts
@@ -265,6 +265,7 @@ export class HypercertOperationsImpl extends EventEmitter<HypercertEvents> imple
     rightsCid: string,
     imageBlobRef: JsonBlobRef | undefined,
     locationRef: { uri: string; cid: string } | undefined,
+    contributorsData: Array<{ contributorIdentity: string; contributionDetails?: string }> | undefined,
     createdAt: string,
     onProgress?: (step: ProgressStep) => void,
   ): Promise<{ uri: string; cid: string }> {
@@ -290,13 +291,21 @@ export class HypercertOperationsImpl extends EventEmitter<HypercertEvents> imple
       hypercertRecord.locations = [{ uri: locationRef.uri, cid: locationRef.cid }];
     }
 
+    // Add contributors if provided (embedded inline per lexicon)
+    if (contributorsData && contributorsData.length > 0) {
+      hypercertRecord.contributors = contributorsData.map((c) => ({
+        contributorIdentity: c.contributorIdentity,
+        contributionDetails: c.contributionDetails,
+      }));
+    }
+
     const hypercertValidation = validate(hypercertRecord, HYPERCERT_COLLECTIONS.CLAIM, "main", false);
     if (!hypercertValidation.success) {
       throw new ValidationError(`Invalid hypercert record: ${hypercertValidation.error?.message}`);
     }
 
     // Generate rKey from stable content hash (idempotency)
-    // Hash the complete claim record including all StrongRefs (rights, location)
+    // Hash the complete claim record including all StrongRefs and embedded data
     // These define the claim's identity per the lexicon.
     const hashInput = {
       title: params.title,
@@ -311,6 +320,8 @@ export class HypercertOperationsImpl extends EventEmitter<HypercertEvents> imple
       rightsData: typeof params.rights === "object" ? params.rights : undefined,
       // Location StrongRef - part of claim identity per lexicon
       locationRef: locationRef,
+      // Contributors - part of claim identity per lexicon
+      contributors: contributorsData,
     };
 
     const contentHash = await sha256Hash(hashInput);
@@ -553,31 +564,32 @@ export class HypercertOperationsImpl extends EventEmitter<HypercertEvents> imple
       result.rightsUri = rightsUri;
       result.rightsCid = rightsCid;
 
-      // Step 4: Create hypercert record (with embedded location and rights StrongRefs)
+      // Step 4: Build contributors data for embedding (if provided)
+      let contributorsData: Array<{ contributorIdentity: string; contributionDetails?: string }> | undefined;
+      if (params.contributions && params.contributions.length > 0) {
+        // Transform SDK contributions format to lexicon format
+        // Each contribution has multiple contributors, so we expand them
+        contributorsData = params.contributions.flatMap((contrib) =>
+          contrib.contributors.map((did) => ({
+            contributorIdentity: did,
+            contributionDetails: contrib.role,
+          })),
+        );
+      }
+
+      // Step 5: Create hypercert record (with embedded location, rights, and contributors)
       const { uri: hypercertUri, cid: hypercertCid } = await this.createHypercertRecord(
         params,
         rightsUri,
         rightsCid,
         imageBlobRef,
         locationRef,
+        contributorsData,
         createdAt,
         params.onProgress,
       );
       result.hypercertUri = hypercertUri;
       result.hypercertCid = hypercertCid;
-
-      // Step 5: Create contributions if provided
-      if (params.contributions && params.contributions.length > 0) {
-        try {
-          result.contributionUris = await this.createContributionsWithProgress(
-            hypercertUri,
-            params.contributions,
-            params.onProgress,
-          );
-        } catch {
-          // Error already logged and progress emitted
-        }
-      }
 
       // Step 6: Add evidence records if provided
       if (params.evidence && params.evidence.length > 0) {

--- a/packages/sdk-core/src/repository/HypercertOperationsImpl.ts
+++ b/packages/sdk-core/src/repository/HypercertOperationsImpl.ts
@@ -548,24 +548,10 @@ export class HypercertOperationsImpl extends EventEmitter<HypercertEvents> imple
 
       // Step 2: Create location record if provided (must be before hypercert)
       // If location is provided, it must succeed - failing silently would change the rKey on retries
-      let locationRef: { uri: string; cid: string } | undefined;
-      if (params.location) {
-        try {
-          this.emitProgress(params.onProgress, { name: "createLocation", status: "start" });
-          locationRef = await this.resolveLocation(params.location);
-          result.locationUri = locationRef.uri;
-          result.locationCid = locationRef.cid;
-          this.emitProgress(params.onProgress, {
-            name: "createLocation",
-            status: "success",
-            data: { uri: locationRef.uri },
-          });
-        } catch (error) {
-          this.emitProgress(params.onProgress, { name: "createLocation", status: "error", error: error as Error });
-          this.logger?.warn(`Failed to create location: ${error instanceof Error ? error.message : "Unknown"}`);
-          // Re-throw to fail the operation - swallowing would change rKey on retry
-          throw error;
-        }
+      const locationRef = await this.processLocation(params.location, params.onProgress);
+      if (locationRef) {
+        result.locationUri = locationRef.uri;
+        result.locationCid = locationRef.cid;
       }
 
       // Step 3: Create rights record
@@ -578,50 +564,7 @@ export class HypercertOperationsImpl extends EventEmitter<HypercertEvents> imple
       result.rightsCid = rightsCid;
 
       // Step 4: Build contributors data for embedding (if provided)
-      let contributorsData:
-        | Array<{ contributorIdentity: string; contributionDetails?: string | { uri: string; cid: string } }>
-        | undefined;
-      if (params.contributions && params.contributions.length > 0) {
-        // Transform SDK contributions format to lexicon format
-        // Handle async creation of contributionDetails records if description is provided
-        const contributorsPromises = params.contributions.map(async (contrib) => {
-          let detailsRef: string | { uri: string; cid: string } = contrib.role;
-
-          // If description is provided, create a detailed record
-          if (contrib.description) {
-            try {
-              this.emitProgress(params.onProgress, { name: "createContribution", status: "start" });
-              const result = await this.addContribution({
-                contributors: contrib.contributors, // Passed for legacy reasons/completeness
-                role: contrib.role,
-                description: contrib.description,
-              });
-              detailsRef = { uri: result.uri, cid: result.cid };
-              this.emitProgress(params.onProgress, {
-                name: "createContribution",
-                status: "success",
-                data: result,
-              });
-            } catch (error) {
-              this.emitProgress(params.onProgress, {
-                name: "createContribution",
-                status: "error",
-                error: error as Error,
-              });
-              throw error;
-            }
-          }
-
-          // Expand to one entry per contributor DID
-          return contrib.contributors.map((did) => ({
-            contributorIdentity: did,
-            contributionDetails: detailsRef,
-          }));
-        });
-
-        const nestedContributors = await Promise.all(contributorsPromises);
-        contributorsData = nestedContributors.flat();
-      }
+      const contributorsData = await this.processContributors(params.contributions, params.onProgress);
 
       // Step 5: Create hypercert record (with embedded location, rights, and contributors)
       const { uri: hypercertUri, cid: hypercertCid } = await this.createHypercertRecord(
@@ -1141,6 +1084,94 @@ export class HypercertOperationsImpl extends EventEmitter<HypercertEvents> imple
       if (error instanceof ValidationError || error instanceof NetworkError) throw error;
       throw new NetworkError(`Failed to add evidence: ${error instanceof Error ? error.message : "Unknown"}`, error);
     }
+  }
+
+  /**
+   * Processes location parameters, creating a location record if necessary.
+   *
+   * @param locationParams - Location parameters from create request
+   * @param onProgress - Optional progress callback
+   * @returns Promise resolving to location StrongRef or undefined
+   * @internal
+   */
+  private async processLocation(
+    locationParams: LocationParams | undefined,
+    onProgress?: (step: ProgressStep) => void,
+  ): Promise<{ uri: string; cid: string } | undefined> {
+    if (!locationParams) return undefined;
+
+    try {
+      this.emitProgress(onProgress, { name: "createLocation", status: "start" });
+      const locationRef = await this.resolveLocation(locationParams);
+      this.emitProgress(onProgress, {
+        name: "createLocation",
+        status: "success",
+        data: { uri: locationRef.uri },
+      });
+      return locationRef;
+    } catch (error) {
+      this.emitProgress(onProgress, { name: "createLocation", status: "error", error: error as Error });
+      this.logger?.warn(`Failed to create location: ${error instanceof Error ? error.message : "Unknown"}`);
+      // Re-throw to fail the operation - swallowing would change rKey on retry
+      throw error;
+    }
+  }
+
+  /**
+   * Processes contribution parameters, creating detailed contribution records if necessary.
+   *
+   * @param contributions - Array of contribution parameters
+   * @param onProgress - Optional progress callback
+   * @returns Promise resolving to flattened array of contributor data for embedding
+   * @internal
+   */
+  private async processContributors(
+    contributions:
+      | Array<{ contributors: string[]; role: string; description?: string; props?: Record<string, unknown> }>
+      | undefined,
+    onProgress?: (step: ProgressStep) => void,
+  ): Promise<
+    Array<{ contributorIdentity: string; contributionDetails?: string | { uri: string; cid: string } }> | undefined
+  > {
+    if (!contributions || contributions.length === 0) return undefined;
+
+    const contributorsPromises = contributions.map(async (contrib) => {
+      let detailsRef: string | { uri: string; cid: string } = contrib.role;
+
+      // If description is provided, create a detailed record
+      if (contrib.description) {
+        try {
+          this.emitProgress(onProgress, { name: "createContribution", status: "start" });
+          const result = await this.addContribution({
+            contributors: contrib.contributors, // Passed for legacy reasons/completeness
+            role: contrib.role,
+            description: contrib.description,
+          });
+          detailsRef = { uri: result.uri, cid: result.cid };
+          this.emitProgress(onProgress, {
+            name: "createContribution",
+            status: "success",
+            data: result,
+          });
+        } catch (error) {
+          this.emitProgress(onProgress, {
+            name: "createContribution",
+            status: "error",
+            error: error as Error,
+          });
+          throw error;
+        }
+      }
+
+      // Expand to one entry per contributor DID
+      return contrib.contributors.map((did) => ({
+        contributorIdentity: did,
+        contributionDetails: detailsRef,
+      }));
+    });
+
+    const nestedContributors = await Promise.all(contributorsPromises);
+    return nestedContributors.flat();
   }
 
   /**

--- a/packages/sdk-core/src/repository/HypercertOperationsImpl.ts
+++ b/packages/sdk-core/src/repository/HypercertOperationsImpl.ts
@@ -537,6 +537,7 @@ export class HypercertOperationsImpl extends EventEmitter<HypercertEvents> imple
       const imageBlobRef = params.image ? await this.uploadImageBlob(params.image, params.onProgress) : undefined;
 
       // Step 2: Create location record if provided (must be before hypercert)
+      // If location is provided, it must succeed - failing silently would change the rKey on retries
       let locationRef: { uri: string; cid: string } | undefined;
       if (params.location) {
         try {
@@ -551,7 +552,8 @@ export class HypercertOperationsImpl extends EventEmitter<HypercertEvents> imple
         } catch (error) {
           this.emitProgress(params.onProgress, { name: "createLocation", status: "error", error: error as Error });
           this.logger?.warn(`Failed to create location: ${error instanceof Error ? error.message : "Unknown"}`);
-          // Don't throw - continue without location
+          // Re-throw to fail the operation - swallowing would change rKey on retry
+          throw error;
         }
       }
 

--- a/packages/sdk-core/src/repository/HypercertOperationsImpl.ts
+++ b/packages/sdk-core/src/repository/HypercertOperationsImpl.ts
@@ -329,9 +329,9 @@ export class HypercertOperationsImpl extends EventEmitter<HypercertEvents> imple
       // Rights definition (what the user specified, not the generated CID)
       rightsData: typeof params.rights === "object" ? params.rights : undefined,
       // Location StrongRef - part of claim identity per lexicon
-      locationRef: locationRef,
+      location: params.location,
       // Contributors - part of claim identity per lexicon
-      contributors: contributorsData,
+      contributors: params.contributions ? params.contributions : undefined,
     };
 
     const contentHash = await sha256Hash(hashInput);

--- a/packages/sdk-core/src/repository/HypercertOperationsImpl.ts
+++ b/packages/sdk-core/src/repository/HypercertOperationsImpl.ts
@@ -576,7 +576,6 @@ export class HypercertOperationsImpl extends EventEmitter<HypercertEvents> imple
       result.rightsCid = rightsCid;
 
       // Step 4: Build contributors data for embedding (if provided)
-      // Step 4: Build contributors data for embedding (if provided)
       let contributorsData:
         | Array<{ contributorIdentity: string; contributionDetails?: string | { uri: string; cid: string } }>
         | undefined;

--- a/packages/sdk-core/src/repository/HypercertOperationsImpl.ts
+++ b/packages/sdk-core/src/repository/HypercertOperationsImpl.ts
@@ -290,14 +290,15 @@ export class HypercertOperationsImpl extends EventEmitter<HypercertEvents> imple
     }
 
     // Generate rKey from stable content hash (idempotency)
-    // We hash the user's intent (params + rights definition), not the volatile outputs (like new rights CID or createdAt)
-
-    // Destructure to remove non-hashable/redundant fields (image, onProgress)
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const { image, onProgress: _onProgress, ...paramsForHash } = params;
-
+    // Hash only the fields that end up in the claim record itself, plus image blob ref and rights data.
+    // Excludes sidecar data (location, contributions, evidence) to keep rKeys stable.
     const hashInput = {
-      ...paramsForHash,
+      title: params.title,
+      description: params.description,
+      shortDescription: params.shortDescription,
+      workScope: params.workScope,
+      startDate: params.startDate,
+      endDate: params.endDate,
       // Use the full image blob reference for identity (handled by stable stringify)
       imageRecord: imageBlobRef,
       // Ensure rights definition is part of identity, but not the new CID

--- a/packages/sdk-core/src/repository/HypercertOperationsImpl.ts
+++ b/packages/sdk-core/src/repository/HypercertOperationsImpl.ts
@@ -315,8 +315,10 @@ export class HypercertOperationsImpl extends EventEmitter<HypercertEvents> imple
     }
 
     // Generate rKey from stable content hash (idempotency)
-    // Hash the complete claim record including all StrongRefs and embedded data
-    // These define the claim's identity per the lexicon.
+    // Use NORMALIZED values (already resolved StrongRefs and processed data)
+    // to ensure JSON-serializability and deterministic hashing.
+    // Raw params.location can contain non-serializable Blobs (GeoJSON),
+    // and params.contributions can have arbitrary/inconsistent props.
     const hashInput = {
       title: params.title,
       description: params.description,
@@ -324,14 +326,25 @@ export class HypercertOperationsImpl extends EventEmitter<HypercertEvents> imple
       workScope: params.workScope,
       startDate: params.startDate,
       endDate: params.endDate,
-      // Image blob reference (CID-based, stable)
-      imageRecord: imageBlobRef,
-      // Rights definition (what the user specified, not the generated CID)
-      rightsData: typeof params.rights === "object" ? params.rights : undefined,
-      // Location StrongRef - part of claim identity per lexicon
-      location: params.location,
-      // Contributors - part of claim identity per lexicon
-      contributors: params.contributions ? params.contributions : undefined,
+      // Image: extract CID string from blob ref (stable content hash)
+      // JsonBlobRef can have ref.$link (upload result) or cid (existing record)
+      imageRef: imageBlobRef
+        ? "ref" in imageBlobRef && imageBlobRef.ref
+          ? imageBlobRef.ref.$link
+          : "cid" in imageBlobRef
+            ? imageBlobRef.cid
+            : undefined
+        : undefined,
+      // Rights: canonical object with only known fields
+      rights: {
+        name: params.rights.name,
+        type: params.rights.type,
+        description: params.rights.description,
+      },
+      // Location: use resolved StrongRef (uri+cid), not raw params which may be Blob
+      locationRef: locationRef ? { uri: locationRef.uri, cid: locationRef.cid } : undefined,
+      // Contributors: use already-processed canonical format from processContributors()
+      contributors: contributorsData,
     };
 
     const contentHash = await sha256Hash(hashInput);

--- a/packages/sdk-core/src/repository/HypercertOperationsImpl.ts
+++ b/packages/sdk-core/src/repository/HypercertOperationsImpl.ts
@@ -252,6 +252,8 @@ export class HypercertOperationsImpl extends EventEmitter<HypercertEvents> imple
    * @param rightsUri - URI of the associated rights record
    * @param rightsCid - CID of the associated rights record
    * @param imageBlobRef - Optional image blob reference
+   * @param locationRef - Optional strong reference to the associated location record
+   * @param contributorsData - Optional array of contributor data (inline or StrongRef) to embed in the claim
    * @param createdAt - ISO timestamp for creation
    * @param onProgress - Optional progress callback
    * @returns Promise resolving to hypercert URI and CID

--- a/packages/sdk-core/src/repository/HypercertOperationsImpl.ts
+++ b/packages/sdk-core/src/repository/HypercertOperationsImpl.ts
@@ -906,26 +906,68 @@ export class HypercertOperationsImpl extends EventEmitter<HypercertEvents> imple
    */
   async attachLocation(hypercertUri: string, location: LocationParams): Promise<CreateResult> {
     try {
-      // Validate that hypercert exists (unused but confirms hypercert is valid)
-      await this.get(hypercertUri);
+      // Validate that hypercert exists and get current record
+      const { record } = await this.get(hypercertUri);
+
+      const uriMatch = hypercertUri.match(/^at:\/\/([^/]+)\/([^/]+)\/(.+)$/);
+      if (!uriMatch) {
+        throw new ValidationError(`Invalid URI format: ${hypercertUri}`);
+      }
+      const [, , collection, rkey] = uriMatch;
+
       const resolvedLocation = await this.resolveLocation(location);
 
-      await this.update({
-        uri: hypercertUri,
-        updates: {
-          location: {
-            $type: "com.atproto.repo.strongRef",
-            uri: resolvedLocation.uri,
-            cid: resolvedLocation.cid,
-          },
-        },
+      // Handle migration: preserve existing locations and migrate legacy 'location'
+      // Use 'any' cast as types might not yet reflect the schema change
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const existingLocations: StrongRef[] = (record as any).locations ? [...(record as any).locations] : [];
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const legacyLocation = (record as any).location;
+
+      if (legacyLocation) {
+        existingLocations.unshift(legacyLocation);
+      }
+
+      existingLocations.push({
+        $type: "com.atproto.repo.strongRef",
+        uri: resolvedLocation.uri,
+        cid: resolvedLocation.cid,
       });
+
+      const recordForUpdate: Record<string, unknown> = {
+        ...record,
+        locations: existingLocations,
+        createdAt: record.createdAt,
+      };
+
+      // Delete legacy location field so the payload is valid against new schema
+      delete recordForUpdate.location;
+
+      const validation = validate(recordForUpdate, collection, "main", false);
+      if (!validation.success) {
+        throw new ValidationError(`Invalid hypercert record: ${validation.error?.message}`);
+      }
+
+      const result = await this.agent.com.atproto.repo.putRecord({
+        repo: this.repoDid,
+        collection,
+        rkey,
+        record: recordForUpdate,
+      });
+
+      if (!result.success) {
+        throw new NetworkError("Failed to attach location");
+      }
 
       this.emit("locationAttached", {
         uri: resolvedLocation.uri,
         cid: resolvedLocation.cid,
         hypercertUri,
       });
+
+      // Also emit recordUpdated since the record structure changed
+      this.emit("recordUpdated", { uri: result.data.uri, cid: result.data.cid });
+
       return { uri: resolvedLocation.uri, cid: resolvedLocation.cid };
     } catch (error) {
       if (error instanceof ValidationError || error instanceof NetworkError) throw error;

--- a/packages/sdk-core/src/repository/HypercertOperationsImpl.ts
+++ b/packages/sdk-core/src/repository/HypercertOperationsImpl.ts
@@ -265,7 +265,9 @@ export class HypercertOperationsImpl extends EventEmitter<HypercertEvents> imple
     rightsCid: string,
     imageBlobRef: JsonBlobRef | undefined,
     locationRef: { uri: string; cid: string } | undefined,
-    contributorsData: Array<{ contributorIdentity: string; contributionDetails?: string }> | undefined,
+    contributorsData:
+      | Array<{ contributorIdentity: string; contributionDetails?: string | { uri: string; cid: string } }>
+      | undefined,
     createdAt: string,
     onProgress?: (step: ProgressStep) => void,
   ): Promise<{ uri: string; cid: string }> {
@@ -291,12 +293,18 @@ export class HypercertOperationsImpl extends EventEmitter<HypercertEvents> imple
       hypercertRecord.locations = [{ uri: locationRef.uri, cid: locationRef.cid }];
     }
 
-    // Add contributors if provided (embedded inline per lexicon)
+    // Add contributors if provided (inline role string or StrongRef per lexicon)
     if (contributorsData && contributorsData.length > 0) {
-      hypercertRecord.contributors = contributorsData.map((c) => ({
-        contributorIdentity: c.contributorIdentity,
-        contributionDetails: c.contributionDetails,
-      }));
+      hypercertRecord.contributors = contributorsData.map((c) => {
+        const contributor: Record<string, unknown> = {
+          contributorIdentity: c.contributorIdentity,
+        };
+        if (c.contributionDetails) {
+          // StrongRef has uri/cid, string is inline role
+          contributor.contributionDetails = c.contributionDetails;
+        }
+        return contributor;
+      });
     }
 
     const hypercertValidation = validate(hypercertRecord, HYPERCERT_COLLECTIONS.CLAIM, "main", false);
@@ -568,16 +576,50 @@ export class HypercertOperationsImpl extends EventEmitter<HypercertEvents> imple
       result.rightsCid = rightsCid;
 
       // Step 4: Build contributors data for embedding (if provided)
-      let contributorsData: Array<{ contributorIdentity: string; contributionDetails?: string }> | undefined;
+      // Step 4: Build contributors data for embedding (if provided)
+      let contributorsData:
+        | Array<{ contributorIdentity: string; contributionDetails?: string | { uri: string; cid: string } }>
+        | undefined;
       if (params.contributions && params.contributions.length > 0) {
         // Transform SDK contributions format to lexicon format
-        // Each contribution has multiple contributors, so we expand them
-        contributorsData = params.contributions.flatMap((contrib) =>
-          contrib.contributors.map((did) => ({
+        // Handle async creation of contributionDetails records if description is provided
+        const contributorsPromises = params.contributions.map(async (contrib) => {
+          let detailsRef: string | { uri: string; cid: string } = contrib.role;
+
+          // If description is provided, create a detailed record
+          if (contrib.description) {
+            try {
+              this.emitProgress(params.onProgress, { name: "createContribution", status: "start" });
+              const result = await this.addContribution({
+                contributors: contrib.contributors, // Passed for legacy reasons/completeness
+                role: contrib.role,
+                description: contrib.description,
+              });
+              detailsRef = { uri: result.uri, cid: result.cid };
+              this.emitProgress(params.onProgress, {
+                name: "createContribution",
+                status: "success",
+                data: result,
+              });
+            } catch (error) {
+              this.emitProgress(params.onProgress, {
+                name: "createContribution",
+                status: "error",
+                error: error as Error,
+              });
+              throw error;
+            }
+          }
+
+          // Expand to one entry per contributor DID
+          return contrib.contributors.map((did) => ({
             contributorIdentity: did,
-            contributionDetails: contrib.role,
-          })),
-        );
+            contributionDetails: detailsRef,
+          }));
+        });
+
+        const nestedContributors = await Promise.all(contributorsPromises);
+        contributorsData = nestedContributors.flat();
       }
 
       // Step 5: Create hypercert record (with embedded location, rights, and contributors)

--- a/packages/sdk-core/tests/lib/crypto.test.ts
+++ b/packages/sdk-core/tests/lib/crypto.test.ts
@@ -64,3 +64,19 @@ describe("stableStringify", () => {
         expect(stableStringify(obj)).toBe('{"id":1,"meta":{"info":{"x":1,"y":2},"tags":["b","a"]}}');
     });
 });
+
+import { sha256Hash } from "../../src/lib/crypto.js";
+import { ValidationError } from "../../src/core/errors.js";
+
+describe("sha256Hash", () => {
+    it("should throw ValidationError for undefined input", async () => {
+        await expect(sha256Hash(undefined)).rejects.toThrow(ValidationError);
+        await expect(sha256Hash(undefined)).rejects.toThrow(/Content illegal: not serializable/);
+    });
+
+    it("should throw ValidationError for function input", async () => {
+        const func = () => { };
+        await expect(sha256Hash(func)).rejects.toThrow(ValidationError);
+        await expect(sha256Hash(func)).rejects.toThrow(/Content illegal: not serializable/);
+    });
+});

--- a/packages/sdk-core/tests/lib/crypto.test.ts
+++ b/packages/sdk-core/tests/lib/crypto.test.ts
@@ -1,0 +1,66 @@
+
+import { describe, it, expect } from "vitest";
+import { stableStringify } from "../../src/lib/crypto.js";
+
+describe("stableStringify", () => {
+    it("should stringify primitives", () => {
+        expect(stableStringify(1)).toBe("1");
+        expect(stableStringify("test")).toBe('"test"');
+        expect(stableStringify(true)).toBe("true");
+        expect(stableStringify(null)).toBe("null");
+    });
+
+    it("should sort object keys", () => {
+        const obj = { c: 3, a: 1, b: 2 };
+        expect(stableStringify(obj)).toBe('{"a":1,"b":2,"c":3}');
+    });
+
+    it("should sort nested object keys", () => {
+        const obj = {
+            z: { y: 2, x: 1 },
+            a: { c: 3, b: 4 },
+        };
+        expect(stableStringify(obj)).toBe('{"a":{"b":4,"c":3},"z":{"x":1,"y":2}}');
+    });
+
+    it("should preserve array order", () => {
+        const arr = [3, 1, 2];
+        expect(stableStringify(arr)).toBe("[3,1,2]");
+    });
+
+    it("should sort objects inside arrays", () => {
+        const arr = [
+            { b: 2, a: 1 },
+            { d: 4, c: 3 },
+        ];
+        expect(stableStringify(arr)).toBe('[{"a":1,"b":2},{"c":3,"d":4}]');
+    });
+
+    it("should ignore undefined, functions, and symbols", () => {
+        const obj = {
+            a: 1,
+            b: undefined,
+            c: () => { },
+            d: Symbol("test"),
+            e: 2,
+        };
+        expect(stableStringify(obj)).toBe('{"a":1,"e":2}');
+    });
+
+    it("should return undefined for non-serializable top-level inputs", () => {
+        expect(stableStringify(undefined)).toBeUndefined();
+        expect(stableStringify(() => { })).toBeUndefined();
+        expect(stableStringify(Symbol("test"))).toBeUndefined();
+    });
+
+    it("should handle mixed complex structures", () => {
+        const obj = {
+            id: 1,
+            meta: {
+                tags: ["b", "a"], // Array order preserved
+                info: { y: 2, x: 1 } // Object keys sorted
+            }
+        };
+        expect(stableStringify(obj)).toBe('{"id":1,"meta":{"info":{"x":1,"y":2},"tags":["b","a"]}}');
+    });
+});

--- a/packages/sdk-core/tests/repository/HypercertOperationsImpl.test.ts
+++ b/packages/sdk-core/tests/repository/HypercertOperationsImpl.test.ts
@@ -161,9 +161,13 @@ describe("HypercertOperationsImpl", () => {
     });
 
     it("should attach location when provided", async () => {
-      // Reset mocks and set up for location
+      // Reset mocks and set up for location (new order: location → rights → hypercert)
       mockAgent.com.atproto.repo.createRecord.mockReset();
       mockAgent.com.atproto.repo.createRecord
+        .mockResolvedValueOnce({
+          success: true,
+          data: { uri: "at://did:plc:test/app.certified.location/ghi", cid: "location-cid" },
+        })
         .mockResolvedValueOnce({
           success: true,
           data: { uri: "at://did:plc:test/org.hypercerts.claim.rights/abc", cid: "rights-cid" },
@@ -171,34 +175,7 @@ describe("HypercertOperationsImpl", () => {
         .mockResolvedValueOnce({
           success: true,
           data: { uri: "at://did:plc:test/org.hypercerts.claim.record/def", cid: "hypercert-cid" },
-        })
-        .mockResolvedValueOnce({
-          success: true,
-          data: { uri: "at://did:plc:test/app.certified.location/ghi", cid: "location-cid" },
         });
-
-      // Mock getRecord for attachLocation's internal get call
-      mockAgent.com.atproto.repo.getRecord.mockResolvedValue({
-        success: true,
-        data: {
-          uri: "at://did:plc:test/org.hypercerts.claim.record/def",
-          cid: "hypercert-cid",
-          value: {
-            title: "Test",
-            description: "Test",
-            workScope: createWorkScopeAll(["Climate"]),
-            startDate: "2024-01-01",
-            endDate: "2024-12-31",
-            createdAt: "2024-01-01",
-          },
-        },
-      });
-
-      // Mock putRecord for the update call
-      mockAgent.com.atproto.repo.putRecord.mockResolvedValue({
-        success: true,
-        data: { uri: "at://did:plc:test/org.hypercerts.claim.record/def", cid: "updated-cid" },
-      });
 
       const result = await hypercertOps.create({
         ...validParams,

--- a/packages/sdk-core/tests/repository/HypercertOperationsImpl.test.ts
+++ b/packages/sdk-core/tests/repository/HypercertOperationsImpl.test.ts
@@ -221,6 +221,45 @@ describe("HypercertOperationsImpl", () => {
       expect(createCall.record.contributors[0].contributionDetails).toBe("Developer");
     });
 
+    it("should create detailed contributions (StrongRef) when description is provided", async () => {
+      mockAgent.com.atproto.repo.createRecord.mockReset();
+      mockAgent.com.atproto.repo.createRecord
+        .mockResolvedValueOnce({
+          success: true,
+          data: { uri: "at://did:plc:test/org.hypercerts.claim.rights/abc", cid: "rights-cid" },
+        })
+        .mockResolvedValueOnce({
+          success: true,
+          data: { uri: "at://did:plc:test/org.hypercerts.claim.contributionDetails/xyz", cid: "details-cid" },
+        })
+        .mockResolvedValueOnce({
+          success: true,
+          data: { uri: "at://did:plc:test/org.hypercerts.claim.record/def", cid: "hypercert-cid" },
+        });
+
+      const result = await hypercertOps.create({
+        ...validParams,
+        contributions: [{ contributors: ["did:plc:contrib1"], role: "Developer", description: "Backend work" }],
+      });
+
+      expect(result.hypercertUri).toBeDefined();
+
+      // Verify contribution details record was created
+      const contributionCall = mockAgent.com.atproto.repo.createRecord.mock.calls[1][0];
+      expect(contributionCall.collection).toBe("org.hypercerts.claim.contributionDetails");
+      expect(contributionCall.record.role).toBe("Developer");
+      expect(contributionCall.record.contributionDescription).toBe("Backend work");
+
+      // Verify contributors use StrongRef in the claim record
+      const createCall = mockAgent.com.atproto.repo.createRecord.mock.calls[2][0];
+      expect(createCall.record.contributors).toBeDefined();
+      expect(createCall.record.contributors[0].contributorIdentity).toBe("did:plc:contrib1");
+      expect(createCall.record.contributors[0].contributionDetails).toEqual({
+        uri: "at://did:plc:test/org.hypercerts.claim.contributionDetails/xyz",
+        cid: "details-cid",
+      });
+    });
+
     it("should call onProgress callback", async () => {
       const onProgress = vi.fn();
 

--- a/packages/sdk-core/tests/repository/HypercertOperationsImpl.test.ts
+++ b/packages/sdk-core/tests/repository/HypercertOperationsImpl.test.ts
@@ -547,7 +547,18 @@ describe("HypercertOperationsImpl", () => {
         $type: "org.hypercerts.defs#uri",
         uri: "https://example.com/location",
       });
+
+      // Verify hypercert update used locations array
+      const putCall = mockAgent.com.atproto.repo.putRecord.mock.calls[0][0];
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const updatedRecord = putCall.record as any;
+      expect(updatedRecord.location).toBeUndefined();
+      expect(updatedRecord.locations).toBeDefined();
+
+      expect(updatedRecord.locations).toHaveLength(1);
+      expect(updatedRecord.locations[0].uri).toBe(result.uri);
     });
+
     it("should attach a location using a GeoJSON Blob", async () => {
       const hypercertUri = "at://did:plc:test/org.hypercerts.claim.record/abc";
       const blob = new Blob([JSON.stringify({ type: "Point", coordinates: [0, 0] })], {
@@ -581,6 +592,16 @@ describe("HypercertOperationsImpl", () => {
           size: 100,
         },
       });
+
+      // Verify hypercert update used locations array
+      const putCall = mockAgent.com.atproto.repo.putRecord.mock.calls[0][0];
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const updatedRecord = putCall.record as any;
+      expect(updatedRecord.location).toBeUndefined();
+      expect(updatedRecord.locations).toBeDefined();
+
+      expect(updatedRecord.locations).toHaveLength(1);
+      expect(updatedRecord.locations[0].uri).toBe(result.uri);
     });
   });
 

--- a/packages/sdk-core/tests/repository/HypercertOperationsImpl.test.ts
+++ b/packages/sdk-core/tests/repository/HypercertOperationsImpl.test.ts
@@ -193,6 +193,7 @@ describe("HypercertOperationsImpl", () => {
     });
 
     it("should create contributions when provided", async () => {
+      // Contributors are now embedded in the claim record, not created as separate records
       mockAgent.com.atproto.repo.createRecord.mockReset();
       mockAgent.com.atproto.repo.createRecord
         .mockResolvedValueOnce({
@@ -202,34 +203,21 @@ describe("HypercertOperationsImpl", () => {
         .mockResolvedValueOnce({
           success: true,
           data: { uri: "at://did:plc:test/org.hypercerts.claim.record/def", cid: "hypercert-cid" },
-        })
-        .mockResolvedValueOnce({
-          success: true,
-          data: { uri: "at://did:plc:test/org.hypercerts.claim.contribution/contrib1", cid: "contrib-cid" },
         });
-
-      mockAgent.com.atproto.repo.getRecord.mockResolvedValue({
-        success: true,
-        data: {
-          uri: "at://did:plc:test/org.hypercerts.claim.record/def",
-          cid: "hypercert-cid",
-          value: {
-            title: "Test",
-            description: "Test",
-            workScope: createWorkScopeAll(["Climate"]),
-            startDate: "2024-01-01",
-            endDate: "2024-12-31",
-            createdAt: "2024-01-01",
-          },
-        },
-      });
 
       const result = await hypercertOps.create({
         ...validParams,
         contributions: [{ contributors: ["did:plc:contrib1"], role: "Developer" }],
       });
 
-      expect(result.contributionUris).toHaveLength(1);
+      expect(result.hypercertUri).toBeDefined();
+
+      // Verify contributors are embedded in the claim record
+      const createCall = mockAgent.com.atproto.repo.createRecord.mock.calls[1][0];
+      expect(createCall.record.contributors).toBeDefined();
+      expect(createCall.record.contributors).toHaveLength(1);
+      expect(createCall.record.contributors[0].contributorIdentity).toBe("did:plc:contrib1");
+      expect(createCall.record.contributors[0].contributionDetails).toBe("Developer");
     });
 
     it("should call onProgress callback", async () => {


### PR DESCRIPTION
## Description

This PR migrates the legacy singular `location` field to the `locations` array in the `HypercertOperationsImpl` class, ensuring compatibility with the latest lexicon updates.

### Changes

- Updated `attachLocation` in `packages/sdk-core/src/repository/HypercertOperationsImpl.ts` to:
  - Detect if a legacy `location` field exists on the record.
  - Migrate it to the `locations` array.
  - Append the new location to the `locations` array.
  - Remove the legacy `location` field from the update payload.
- Verified `createHypercertRecord` uses the `locations` array correctly.
- Updated tests in `packages/sdk-core/tests/repository/HypercertOperationsImpl.test.ts` to verify:
  - The legacy field is removed.
  - The `locations` array is populated correctly.
  - Both singular string URI and Blob inputs work as expected.

### Verification

Ran `pnpm test` in `packages/sdk-core` and verified all tests passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Deterministic content hashing for hypercert record creation ensures consistent, reproducible record identifiers.
  * Direct embedding of location and contributor data in hypercert records at creation time.

* **Bug Fixes**
  * Improved stability and reliability of record key generation for activity claims.
  * Automatic migration of legacy location field data to new locations array format.

* **Tests**
  * Comprehensive test coverage for deterministic hashing behavior and record creation flows.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->