### PR TITLE
feat: rename evidence to attachments and update schema

### DIFF
--- a/.changeset/evidence-to-attachment-rename.md
+++ b/.changeset/evidence-to-attachment-rename.md
@@ -1,0 +1,58 @@
+---
+"@hypercerts-org/sdk-core": minor
+---
+
+Rename evidence records to attachments and update schema to match lexicon changes
+
+**Breaking Changes:**
+
+**API Symbol Renames:**
+
+- `addEvidence()` → `addAttachment()`
+- `CreateHypercertEvidenceParams` → `CreateAttachmentParams`
+- `evidenceUris` → `attachmentUris` in create results
+- `evidenceAdded` → `attachmentAdded` event
+- Evidence type exports replaced with Attachment equivalents
+
+**Schema Field Changes:**
+
+**Subject Fields:**
+
+- `subjectUri` (string) → `subjects` (array of StrongRefs or a single uri or StrongRef)
+- `subject` (StrongRef) → `subjects` (array of StrongRefs or a single uri or StrongRef)
+
+**Content Fields:**
+
+- `content` (string | Blob) | Array<(string | Blob)> → `content` (required array of URI/Blob refs)
+- Content is now required and can be an array with multiple items or a single item. SDK will convert to an array
+
+**Removed Fields:**
+
+- `relationType` - removed from attachment schema
+- `contributors` - removed from attachment schema
+- `locations` - removed from attachment schema
+
+**Payload Mapping Examples:**
+
+```typescript
+// Old evidence payload
+{
+  subjectUri: "at://did:plc:abc/org.hypercerts.claim.activity/xyz",
+  content: "https://example.com/report.pdf",
+  title: "Report",
+  relationType: "supports"
+}
+
+// New attachment payload
+{
+  subjects: "at://did:plc:abc/org.hypercerts.claim.activity/xyz",
+  content: "https://example.com/report.pdf",
+  title: "Report"
+  // relationType removed
+}
+// or arrays:
+{
+  subjects: ["at://did:plc:abc/org.hypercerts.claim.activity/xyz", "at://did:plc:abc/org.hypercerts.claim.activity/zyx"]
+  content: ["https://reportfile.com/pdf", File]
+}
+```

--- a/packages/sdk-core/src/index.ts
+++ b/packages/sdk-core/src/index.ts
@@ -91,7 +91,6 @@ export type {
   OrganizationOperations,
   CreateHypercertParams,
   CreateHypercertResult,
-  CreateHypercertEvidenceParams,
   CreateOrganizationParams,
   LocationParams,
   ContributionDetailsParams,
@@ -162,7 +161,7 @@ export type {
   BadgeResponse,
   FundingReceipt,
   // SDK-specific types
-  HypercertEvidence,
+  HypercertAttachment,
   HypercertImage,
   HypercertImageRecord,
   BlobRef,
@@ -171,6 +170,9 @@ export type {
   HypercertProjectWithMetadata,
   CreateProjectParams,
   UpdateProjectParams,
+  CreateAttachmentParams,
+  UpdateAttachmentParams,
+  AttachmentParams,
 } from "./services/hypercerts/types.js";
 
 // Re-export ATProto lexicon types

--- a/packages/sdk-core/src/lexicons.ts
+++ b/packages/sdk-core/src/lexicons.ts
@@ -168,15 +168,9 @@ export const HYPERCERT_COLLECTIONS = {
   EVALUATION: EVALUATION_NSID,
 
   /**
-   * Attachment record collection (formerly evidence).
-   * @remarks Renamed from EVIDENCE in beta.13
+   * Attachment record collection.
    */
   ATTACHMENT: ATTACHMENT_NSID,
-
-  /**
-   * @deprecated Use ATTACHMENT instead. Renamed in beta.13.
-   */
-  EVIDENCE: ATTACHMENT_NSID,
 
   /**
    * Collection record collection (groups of hypercerts).

--- a/packages/sdk-core/src/lexicons/sidecar.ts
+++ b/packages/sdk-core/src/lexicons/sidecar.ts
@@ -168,7 +168,7 @@ export async function attachSidecar(repo: Repository, params: AttachSidecarParam
  * This orchestrates the creation of a main record followed by one or more
  * sidecar records that reference it. This is useful for workflows like:
  * - Creating a project with multiple hypercert claims
- * - Creating a hypercert with evidence and evaluation records
+ * - Creating a hypercert with attachments and evaluation records
  *
  * @param repo - The repository instance
  * @param params - Parameters including the main record and sidecar definitions

--- a/packages/sdk-core/src/repository/HypercertOperationsImpl.ts
+++ b/packages/sdk-core/src/repository/HypercertOperationsImpl.ts
@@ -36,9 +36,9 @@ import {
   type UpdateProjectParams,
   type CreateMeasurementParams,
   type UpdateMeasurementParams,
+  type CreateAttachmentParams,
 } from "../services/hypercerts/types.js";
 import type {
-  CreateHypercertEvidenceParams,
   LocationParams,
   CreateHypercertParams,
   CreateHypercertResult,
@@ -470,38 +470,38 @@ export class HypercertOperationsImpl extends EventEmitter<HypercertEvents> imple
   }
 
   /**
-   * Creates evidence records with progress tracking.
+   * Creates attachment records and returns their URIs.
    *
-   * @param hypercertUri - URI of the hypercert
-   * @param evidenceItems - Array of evidence data (without subjectUri)
+   * @param hypercertUri - URI of the parent hypercert
+   * @param attachmentItems - Array of attachment items to create
    * @param onProgress - Optional progress callback
-   * @returns Promise resolving to array of evidence URIs
+   * @returns Promise resolving to array of attachment URIs
    * @internal
    */
-  private async createEvidenceWithProgress(
+  private async createAttachmentsWithProgress(
     hypercertUri: string,
-    evidenceItems: Array<Omit<CreateHypercertEvidenceParams, "subjectUri">>,
+    attachmentItems: Array<Omit<CreateAttachmentParams, "subjects">>,
     onProgress?: (step: ProgressStep) => void,
   ): Promise<string[]> {
-    this.emitProgress(onProgress, { name: "addEvidence", status: "start" });
+    this.emitProgress(onProgress, { name: "addAttachment", status: "start" });
     try {
-      const evidenceUris = await Promise.all(
-        evidenceItems.map((evidence) =>
-          this.addEvidence({
-            subjectUri: hypercertUri,
-            ...evidence,
-          } as CreateHypercertEvidenceParams).then((result) => result.uri),
+      const attachmentUris = await Promise.all(
+        attachmentItems.map((attachment) =>
+          this.addAttachment({
+            ...attachment,
+            subjects: hypercertUri,
+          } as CreateAttachmentParams).then((result) => result.uri),
         ),
       );
       this.emitProgress(onProgress, {
-        name: "addEvidence",
+        name: "addAttachment",
         status: "success",
-        data: { count: evidenceUris.length },
+        data: { count: attachmentUris.length },
       });
-      return evidenceUris;
+      return attachmentUris;
     } catch (error) {
-      this.emitProgress(onProgress, { name: "addEvidence", status: "error", error: error as Error });
-      this.logger?.warn(`Failed to create evidence: ${error instanceof Error ? error.message : "Unknown"}`);
+      this.emitProgress(onProgress, { name: "addAttachment", status: "error", error: error as Error });
+      this.logger?.warn(`Failed to create attachments: ${error instanceof Error ? error.message : "Unknown"}`);
       throw error;
     }
   }
@@ -534,7 +534,7 @@ export class HypercertOperationsImpl extends EventEmitter<HypercertEvents> imple
    * - `createHypercert`: Main hypercert record creation
    * - `attachLocation`: Location record creation
    * - `createContributions`: Contribution records creation
-   * - `addEvidence`: Evidence records creation
+   * - `addAttachment`: Attachment records creation
    *
    * @example Minimal hypercert
    * ```typescript
@@ -569,7 +569,7 @@ export class HypercertOperationsImpl extends EventEmitter<HypercertEvents> imple
    *     { contributors: ["did:plc:org1"], role: "coordinator" },
    *     { contributors: ["did:plc:org2"], role: "implementer" },
    *   ],
-   *   evidence: [{ uri: "https://...", description: "Satellite data" }],
+   *   attachments: [{ uri: "https://...", description: "Satellite data" }],
    *   onProgress: console.log,
    * });
    * ```
@@ -621,10 +621,14 @@ export class HypercertOperationsImpl extends EventEmitter<HypercertEvents> imple
       result.hypercertUri = hypercertUri;
       result.hypercertCid = hypercertCid;
 
-      // Step 6: Add evidence records if provided
-      if (params.evidence && params.evidence.length > 0) {
+      // Step 6: Add attachment records if provided
+      if (params.attachments && params.attachments.length > 0) {
         try {
-          result.evidenceUris = await this.createEvidenceWithProgress(hypercertUri, params.evidence, params.onProgress);
+          result.attachmentUris = await this.createAttachmentsWithProgress(
+            hypercertUri,
+            params.attachments,
+            params.onProgress,
+          );
         } catch {
           // Error already logged and progress emitted
         }
@@ -1020,7 +1024,7 @@ export class HypercertOperationsImpl extends EventEmitter<HypercertEvents> imple
   }
 
   /**
-   * Check if an AttachLocationParams is the object form (not a StrongRef or string).
+   * Check if an AttachLocationParams is the object form (not a StrongRef or string or Blob).
    * @internal
    */
   private isLocationObject(location: LocationParams): location is CreateLocationParams {
@@ -1029,7 +1033,8 @@ export class HypercertOperationsImpl extends EventEmitter<HypercertEvents> imple
       !("uri" in location) &&
       !("cid" in location) &&
       location !== null &&
-      !Array.isArray(location)
+      !Array.isArray(location) &&
+      !(location instanceof Blob)
     );
   }
 
@@ -1101,62 +1106,136 @@ export class HypercertOperationsImpl extends EventEmitter<HypercertEvents> imple
   }
 
   /**
-   * TODO: Match Attachment Lexicon
-   * Adds evidence to any subject via the subject ref.
+   * Resolves attachment subjects to an array of StrongRefs.
+   * Accepts single or multiple subjects and normalizes to StrongRef array.
    *
-   * @param evidence - HypercertEvidenceInput
-   * @returns Promise resolving to update result
+   * @param subjectsInput - Single subject or array of subjects (URI strings or StrongRefs)
+   * @returns Promise resolving to array of StrongRefs
+   * @throws {@link ValidationError} if subject format is invalid
+   * @throws {@link NetworkError} if fetching subject record fails
+   * @internal
+   */
+  private async resolveAttachmentSubjects(
+    subjectsInput: string | StrongRef | Array<string | StrongRef>,
+  ): Promise<StrongRef[]> {
+    const subjectsArray = Array.isArray(subjectsInput) ? subjectsInput : [subjectsInput];
+
+    return await Promise.all(subjectsArray.map((subject) => this.resolveToStrongRef(subject)));
+  }
+
+  /**
+   * Resolves attachment content items to an array of URI or Blob references.
+   * Accepts single or multiple content items and normalizes to array.
+   * Uploads Blob content and formats URI content.
+   *
+   * @param contentInput - Single content item or array (URI strings or Blobs)
+   * @returns Promise resolving to array of URI refs or Blob refs
+   * @throws {@link NetworkError} if blob upload fails
+   * @internal
+   */
+  private async resolveAttachmentContent(contentInput: string | Blob | Array<string | Blob>) {
+    const contentArray = Array.isArray(contentInput) ? contentInput : [contentInput];
+
+    return await Promise.all(contentArray.map((item) => this.resolveUriOrBlob(item, "application/octet-stream")));
+  }
+
+  /**
+   * Builds an attachment record from resolved components.
+   *
+   * @param subjects - Resolved subject StrongRefs
+   * @param content - Resolved content items (URI or Blob refs)
+   * @param locationRef - Optional resolved location StrongRef
+   * @param rest - Remaining attachment parameters (title, description, etc.)
+   * @returns Fully constructed attachment record
+   * @internal
+   */
+  private buildAttachmentRecord(
+    subjects: StrongRef[],
+    content: Awaited<ReturnType<typeof this.resolveAttachmentContent>>,
+    locationRef: StrongRef | undefined,
+    rest: Omit<CreateAttachmentParams, "subjects" | "content" | "location">,
+  ): HypercertAttachment {
+    const createdAt = new Date().toISOString();
+
+    return {
+      ...rest,
+      $type: rest.$type ?? HYPERCERT_COLLECTIONS.ATTACHMENT,
+      createdAt: rest.createdAt ?? createdAt,
+      subjects,
+      content,
+      ...(locationRef && { location: locationRef }),
+    } as HypercertAttachment;
+  }
+
+  /**
+   * Adds an attachment to any subject record.
+   *
+   * Attachments provide commentary, context, evidence, or documentary material
+   * related to hypercert records.
+   *
+   * @param attachment - Attachment parameters
+   * @returns Promise resolving to attachment record URI and CID
    * @throws {@link ValidationError} if validation fails
    * @throws {@link NetworkError} if the operation fails
    *
-   * @example
+   * @example Single subject with URI content
    * ```typescript
-   * await repo.hypercerts.addEvidence({
-   *   subjectUri: "at://did:plc:u7h3dstby64di67bxaotzxcz/org.hypercerts.claim.activity/3mbvv5d7ixh2g"
-   *   content: Blob,
-   *   title: "Meeting Notes",
-   *   shortDescription: "Meetings notes from the 3rd of December 2025",
-   *   description: "The meeting with the board of directors and audience on 2025 in regards to the ecological landscape",
-   *   relationType: "supports",
-   * })
+   * await repo.hypercerts.addAttachment({
+   *   subjects: "at://did:plc:u7h3dstby64di67bxaotzxcz/org.hypercerts.claim.activity/3mbvv5d7ixh2g",
+   *   content: "https://example.com/report.pdf",
+   *   title: "Impact Report",
+   *   contentType: "report"
+   * });
+   * ```
+   *
+   * @example Multiple subjects with mixed content
+   * ```typescript
+   * await repo.hypercerts.addAttachment({
+   *   subjects: [
+   *     "at://did:plc:abc/org.hypercerts.claim.activity/xyz",
+   *     { uri: "at://...", cid: "..." }
+   *   ],
+   *   content: [
+   *     "https://example.com/report.pdf",
+   *     new Blob(["data"], { type: "application/pdf" })
+   *   ],
+   *   title: "Multi-source Evidence",
+   *   location: { uri: "at://...", cid: "..." }
+   * });
    * ```
    */
-  async addEvidence(evidence: CreateHypercertEvidenceParams): Promise<UpdateResult> {
+  async addAttachment(attachment: CreateAttachmentParams): Promise<UpdateResult> {
     try {
-      const { subjectUri, content, ...rest } = evidence;
-      const subject = await this.get(subjectUri);
-      const createdAt = new Date().toISOString();
+      const { subjects: subjectsInput, content: contentInput, location: locationInput, ...rest } = attachment;
 
-      const evidenceContent = await this.resolveUriOrBlob(content, "application/octet-stream");
-      // Note: In beta.13, evidence was renamed to attachment with schema changes
-      // - subject -> subjects (array)
-      // - content is now an array
-      // This is a temporary fix to maintain backward compatibility
-      // and since evidence is no longer available in the lexicons
-      const evidenceRecord: HypercertAttachment = {
-        ...rest,
-        $type: HYPERCERT_COLLECTIONS.ATTACHMENT,
-        createdAt,
-        content: [evidenceContent], // content is now an array
-        subjects: [{ uri: subject.uri, cid: subject.cid }], // subject -> subjects array
-      };
-      const validation = validate(evidenceRecord, HYPERCERT_COLLECTIONS.ATTACHMENT, "main", false);
+      if (!contentInput) {
+        throw new ValidationError("content is required for attachments");
+      }
+      const [subjects, content, locationRef] = await Promise.all([
+        this.resolveAttachmentSubjects(subjectsInput),
+        this.resolveAttachmentContent(contentInput),
+        locationInput ? this.resolveLocation(locationInput) : Promise.resolve(undefined),
+      ]);
+      const attachmentRecord = this.buildAttachmentRecord(subjects, content, locationRef, rest);
+      const validation = validate(attachmentRecord, HYPERCERT_COLLECTIONS.ATTACHMENT, "main", false);
       if (!validation.success) {
-        throw new ValidationError(`Invalid evidence record: ${validation.error?.message}`);
+        throw new ValidationError(`Invalid attachment record: ${validation.error?.message}`);
       }
       const result = await this.agent.com.atproto.repo.createRecord({
         repo: this.repoDid,
-        collection: HYPERCERT_COLLECTIONS.EVIDENCE,
-        record: evidenceRecord,
+        collection: HYPERCERT_COLLECTIONS.ATTACHMENT,
+        record: attachmentRecord,
       });
+
       if (!result.success) {
-        throw new NetworkError(`Failed to add evidence`);
+        throw new NetworkError(`Failed to add attachment`);
       }
-      this.emit("evidenceAdded", { uri: result.data.uri, cid: result.data.cid });
+      this.emit("attachmentAdded", { uri: result.data.uri, cid: result.data.cid });
+
       return { uri: result.data.uri, cid: result.data.cid };
     } catch (error) {
       if (error instanceof ValidationError || error instanceof NetworkError) throw error;
-      throw new NetworkError(`Failed to add evidence: ${error instanceof Error ? error.message : "Unknown"}`, error);
+      throw new NetworkError(`Failed to add attachment: ${error instanceof Error ? error.message : "Unknown"}`, error);
     }
   }
 

--- a/packages/sdk-core/src/repository/Repository.ts
+++ b/packages/sdk-core/src/repository/Repository.ts
@@ -401,7 +401,7 @@ export class Repository {
    * High-level hypercert operations.
    *
    * Provides a convenient API for creating and managing hypercerts,
-   * including related records like locations, contributions, and evidence.
+   * including related records like locations, contributions, and attachments.
    *
    * @returns {@link HypercertOperations} interface with EventEmitter capabilities
    *

--- a/packages/sdk-core/src/repository/interfaces.ts
+++ b/packages/sdk-core/src/repository/interfaces.ts
@@ -22,6 +22,7 @@ import type {
   UpdateProjectParams,
   CreateMeasurementParams,
   UpdateMeasurementParams,
+  CreateAttachmentParams,
   StrongRef,
 } from "../services/hypercerts/types.js";
 import type {
@@ -146,7 +147,7 @@ export type ResolvedContributorIdentity = string | { uri: string; cid: string; $
  * Parameters for creating a new hypercert.
  *
  * This interface defines all the data needed to create a hypercert
- * along with optional related records (location, contributions, evidence).
+ * along with optional related records (location, contributions, attachments).
  *
  * @example Minimal hypercert
  * ```typescript
@@ -199,9 +200,10 @@ export type ResolvedContributorIdentity = string | { uri: string; cid: string; $
  *       description: "On-ground planting and monitoring",
  *     },
  *   ],
- *   evidence: [
+ *   attachments: [
  *     {
- *       uri: "https://example.com/satellite-data",
+ *       content: "https://example.com/satellite-data",
+ *       title: "Reforestation Progress",
  *       description: "Satellite imagery showing reforestation progress",
  *     },
  *   ],
@@ -379,9 +381,9 @@ export interface CreateHypercertParams {
   }>;
 
   /**
-   * Optional evidence supporting the impact claim.
+   * Optional attachments supporting or refuting the impact claim.
    */
-  evidence?: Array<Omit<CreateHypercertEvidenceParams, "subjectUri">>;
+  attachments?: Array<Omit<CreateAttachmentParams, "subjects">>;
 
   /**
    * Optional callback for progress updates during creation.
@@ -407,51 +409,6 @@ export interface CreateOrganizationParams {
    * Optional description of the organization
    */
   description?: string;
-}
-/**
- * Input params for creating Hypercert evidence.
- *
- * Based on `org.hypercerts.claim.evidence` but:
- * - removes: $type, createdAt, subject, content
- * - adds: subjectUri, content (string | Blob)
- */
-export interface CreateHypercertEvidenceParams {
-  /**
-   * URI for the subject this evidence is attached to.
-   */
-  subjectUri: string;
-
-  /**
-   * Evidence content.
-   * - string: should be a URI.
-   * - Blob: binary payload (e.g. image/pdf)
-   */
-  content: string | Blob;
-
-  /**
-   * Title to describe the nature of the evidence.
-   */
-  title: string;
-
-  /**
-   * Short description explaining what this evidence shows.
-   */
-  shortDescription?: string;
-
-  /**
-   * Longer description describing the evidence in more detail.
-   */
-  description?: string;
-
-  /**
-   * How this evidence relates to the subject.
-   */
-  relationType?: "supports" | "challenges" | "clarifies" | (string & {});
-
-  /**
-   * Any additional custom fields supported by the record.
-   */
-  [k: string]: unknown;
 }
 
 /**
@@ -496,9 +453,9 @@ export interface CreateHypercertResult {
   contributionUris?: string[];
 
   /**
-   * AT-URIs of evidence records, if evidence was provided.
+   * AT-URIs of attachment records, if attachments were provided.
    */
-  evidenceUris?: string[];
+  attachmentUris?: string[];
 }
 
 // ============================================================================
@@ -792,9 +749,9 @@ export interface HypercertEvents {
   contributorCreated: { uri: string; cid: string };
 
   /**
-   * Emitted when evidence is added to a hypercert.
+   * Emitted when an attachment is added to a subject.
    */
-  evidenceAdded: { uri: string; cid: string };
+  attachmentAdded: { uri: string; cid: string };
 
   /**
    * Emitted when a collection is created.
@@ -948,12 +905,43 @@ export interface HypercertOperations extends EventEmitter<HypercertEvents> {
   attachLocation(uri: string, location: LocationParams): Promise<CreateResult>;
 
   /**
-   * Adds evidence to an existing hypercert.
+   * Adds an attachment to any subject record.
    *
-   * @param evidence - Evidence item to add
-   * @returns Promise resolving to update result
+   * Attachments provide commentary, context, evidence, or documentary material
+   * related to hypercert records. Renamed from `addEvidence` in beta.13.
+   *
+   * @param attachment - Attachment parameters (see {@link CreateAttachmentParams})
+   * @returns Promise resolving to attachment record URI and CID
+   * @throws {@link ValidationError} if validation fails
+   * @throws {@link NetworkError} if the operation fails
+   *
+   * @example Single subject with URI content
+   * ```typescript
+   * await repo.hypercerts.addAttachment({
+   *   subjects: "at://did:plc:abc/org.hypercerts.claim.activity/xyz",
+   *   content: "https://example.com/report.pdf",
+   *   title: "Impact Report",
+   *   contentType: "report"
+   * });
+   * ```
+   *
+   * @example Multiple subjects with mixed content
+   * ```typescript
+   * await repo.hypercerts.addAttachment({
+   *   subjects: [
+   *     "at://did:plc:abc/org.hypercerts.claim.activity/xyz",
+   *     "at://did:plc:abc/org.hypercerts.claim.activity/def"
+   *   ],
+   *   content: [
+   *     "https://example.com/report.pdf",
+   *     new Blob(["data"], { type: "application/pdf" })
+   *   ],
+   *   title: "Multi-source Evidence",
+   *   location: { uri: "at://...", cid: "..." }
+   * });
+   * ```
    */
-  addEvidence(evidence: CreateHypercertEvidenceParams): Promise<UpdateResult>;
+  addAttachment(attachment: CreateAttachmentParams): Promise<UpdateResult>;
 
   /**
    * Creates a contribution record.

--- a/packages/sdk-core/src/services/hypercerts/types.ts
+++ b/packages/sdk-core/src/services/hypercerts/types.ts
@@ -151,17 +151,12 @@ export type HypercertContributor = OrgHypercertsClaimActivity.Contributor;
 export type HypercertMeasurement = OrgHypercertsClaimMeasurement.Main;
 export type HypercertEvaluation = OrgHypercertsClaimEvaluation.Main;
 /**
- * Hypercert attachment record (formerly evidence).
+ * Hypercert attachment record.
  *
- * Renamed from `HypercertEvidence` in beta.13. Attachments provide
- * commentary, context, evidence, or documentary material related
- * to hypercert records.
+ * Attachments provide commentary, context, evidence, or documentary
+ * material related to hypercert records.
  */
 export type HypercertAttachment = OrgHypercertsClaimAttachment.Main;
-/**
- * @deprecated Use `HypercertAttachment` instead. Evidence was renamed to Attachment in beta.13.
- */
-export type HypercertEvidence = HypercertAttachment;
 export type HypercertCollection = OrgHypercertsClaimCollection.Main;
 
 /**
@@ -499,3 +494,118 @@ export type UpdateMeasurementParams = Partial<Except<CreateMeasurementParams, "s
  * ```
  */
 export type MeasurementParams = string | StrongRef | CreateMeasurementParams;
+
+// ============================================================================
+// Attachment Types
+// ============================================================================
+
+/**
+ * SDK input parameters for creating an attachment.
+ *
+ * Attachments provide commentary, context, evidence, or documentary material
+ * related to hypercert records.
+ *
+ * @remarks
+ * Schema structure (beta.13+):
+ * - `subjects` (array) - one or more subject records this attachment relates to
+ * - `content` (required array) - one or more URIs or blob references
+ * - `contentType` (optional) - type/category of the content
+ * - `location` (optional) - associated geographic location
+ * - Rich text facets support for descriptions
+ *
+ * Both `subjects` and `content` accept single values or arrays for convenience,
+ * and will be normalized to arrays internally.
+ *
+ * @example Single subject with single content
+ * ```typescript
+ * const params: CreateAttachmentParams = {
+ *   subjects: "at://did:plc:abc/org.hypercerts.claim.activity/xyz",
+ *   content: "https://example.com/report.pdf",
+ *   title: "Impact Report",
+ *   contentType: "report"
+ * };
+ * ```
+ *
+ * @example Multiple subjects with mixed content
+ * ```typescript
+ * const params: CreateAttachmentParams = {
+ *   subjects: [
+ *     "at://did:plc:abc/org.hypercerts.claim.activity/xyz",
+ *     { uri: "at://...", cid: "..." }
+ *   ],
+ *   content: [
+ *     "https://example.com/report.pdf",
+ *     new Blob(["data"], { type: "application/pdf" })
+ *   ],
+ *   title: "Multi-source Evidence",
+ *   location: { uri: "at://did:plc:.../app.certified.location/...", cid: "..." }
+ * };
+ * ```
+ *
+ * @example With rich text facets
+ * ```typescript
+ * const params: CreateAttachmentParams = {
+ *   subjects: "at://did:plc:abc/org.hypercerts.claim.activity/xyz",
+ *   content: "https://example.com/report.pdf",
+ *   title: "Report",
+ *   shortDescription: "Report by @alice",
+ *   shortDescriptionFacets: [
+ *     {
+ *       index: { byteStart: 10, byteEnd: 16 },
+ *       features: [{ $type: "app.bsky.richtext.facet#mention", did: "did:plc:alice" }]
+ *     }
+ *   ]
+ * };
+ * ```
+ */
+export type CreateAttachmentParams = OverrideProperties<
+  SetOptional<HypercertAttachment, "$type" | "createdAt">,
+  {
+    /**
+     * Subject(s) this attachment relates to.
+     * Can be:
+     * - Single AT-URI string (will fetch CID to create StrongRef)
+     * - Single StrongRef (uri + cid)
+     * - Array of AT-URIs or StrongRefs
+     *
+     * Will be normalized to an array of StrongRefs internally.
+     */
+    subjects: string | StrongRef | Array<string | StrongRef>;
+
+    /**
+     * Content of the attachment.
+     * Can be:
+     * - Single URI string
+     * - Single Blob (will be uploaded)
+     * - Array of URIs and/or Blobs
+     *
+     * Will be normalized to an array internally.
+     * This field is required.
+     */
+    content: string | Blob | Array<string | Blob>;
+
+    /**
+     * Optional location to attach.
+     * Can be:
+     * - StrongRef to reference existing location (uri + cid)
+     * - string (AT-URI) to reference existing location (CID will be fetched)
+     * - Location object to create a new location record
+     */
+    location?: LocationParams;
+  }
+>;
+
+/**
+ * SDK input parameters for updating an attachment.
+ * All fields are optional for partial updates.
+ */
+export type UpdateAttachmentParams = Partial<CreateAttachmentParams>;
+
+/**
+ * Union type for specifying an attachment reference.
+ * Can be:
+ * - AT-URI string pointing to existing attachment
+ * - StrongRef with uri and cid
+ * - Full attachment params object to create new attachment
+ */
+export type AttachmentParams = string | StrongRef | CreateAttachmentParams;

--- a/packages/sdk-core/src/types.ts
+++ b/packages/sdk-core/src/types.ts
@@ -79,7 +79,6 @@ export type {
   HypercertCollection,
   HypercertCollectionItem,
   HypercertWorkScopeTag,
-  HypercertEvidence,
   HypercertImage,
   HypercertImageRecord,
   HypercertWithMetadata,

--- a/packages/sdk-core/tests/repository/HypercertOperationsImpl.test.ts
+++ b/packages/sdk-core/tests/repository/HypercertOperationsImpl.test.ts
@@ -132,17 +132,16 @@ describe("HypercertOperationsImpl", () => {
       expect(hypercertCall.record.descriptionFacets).toBeUndefined();
     });
 
-    it("should create evidence records when provided", async () => {
-      const evidence = [
+    it("should create attachment records when provided", async () => {
+      const attachments = [
         {
-          content: "https://example.com/evidence",
-          title: "Evidence Document",
-          shortDescription: "Supporting evidence",
-          relationType: "supports" as const,
+          content: "https://example.com/attachment",
+          title: "Attachment Document",
+          shortDescription: "Supporting attachment",
         },
       ];
 
-      // Mock getRecord for evidence creation (called by addEvidence)
+      // Mock getRecord for attachment creation (called by addAttachment)
       mockAgent.com.atproto.repo.getRecord.mockResolvedValue({
         success: true,
         data: {
@@ -160,28 +159,26 @@ describe("HypercertOperationsImpl", () => {
       });
 
       // Mock attachment record creation (third createRecord call after rights and hypercert)
-      // Note: In beta.13, evidence was renamed to attachment
       mockAgent.com.atproto.repo.createRecord.mockResolvedValueOnce({
         success: true,
-        data: { uri: "at://did:plc:test/org.hypercerts.claim.attachment/attachment123", cid: "evidence-cid" },
+        data: { uri: "at://did:plc:test/org.hypercerts.claim.attachment/attachment123", cid: "attachment-cid" },
       });
 
       const result = await hypercertOps.create({
         ...validParams,
-        evidence,
+        attachments,
       });
 
-      // Verify evidence records were created
-      expect(result.evidenceUris).toBeDefined();
-      expect(result.evidenceUris).toHaveLength(1);
-      // Note: In beta.13, evidence was renamed to attachment
-      expect(result.evidenceUris?.[0]).toContain("attachment");
+      // Verify attachment records were created
+      expect(result.attachmentUris).toBeDefined();
+      expect(result.attachmentUris).toHaveLength(1);
+      expect(result.attachmentUris?.[0]).toContain("attachment");
 
       // Verify createRecord was called for attachment (3rd call: rights, hypercert, attachment)
       expect(mockAgent.com.atproto.repo.createRecord).toHaveBeenCalledTimes(3);
-      const evidenceCall = mockAgent.com.atproto.repo.createRecord.mock.calls[2][0];
-      expect(evidenceCall.collection).toBe("org.hypercerts.claim.attachment");
-      expect(evidenceCall.record.title).toBe("Evidence Document");
+      const attachmentCall = mockAgent.com.atproto.repo.createRecord.mock.calls[2][0];
+      expect(attachmentCall.collection).toBe("org.hypercerts.claim.attachment");
+      expect(attachmentCall.record.title).toBe("Attachment Document");
     });
 
     it("should attach location when provided", async () => {
@@ -1073,12 +1070,12 @@ describe("HypercertOperationsImpl", () => {
     });
   });
 
-  describe("addEvidence", () => {
+  describe("addAttachment", () => {
     beforeEach(() => {
       mockAgent.com.atproto.repo.getRecord.mockResolvedValue({
         success: true,
         data: {
-          uri: "at://did:plc:test/org.hypercerts.claim.record/abc",
+          uri: "at://did:plc:test/org.hypercerts.claim.activity/abc",
           cid: "hypercert-cid",
           value: {
             title: "Test",
@@ -1091,34 +1088,45 @@ describe("HypercertOperationsImpl", () => {
         },
       });
 
-      // Note: In beta.13, evidence was renamed to attachment
       mockAgent.com.atproto.repo.createRecord.mockResolvedValue({
         success: true,
-        data: { uri: "at://did:plc:test/org.hypercerts.claim.attachment/xyz", cid: "evidence-cid" },
+        data: { uri: "at://did:plc:test/org.hypercerts.claim.attachment/xyz", cid: "attachment-cid" },
       });
     });
 
-    it("should add evidence to a hypercert with a URI string", async () => {
-      const result = await hypercertOps.addEvidence({
-        subjectUri: "at://did:plc:test/org.hypercerts.claim.record/abc",
+    it("should add attachment with single subject (string) and single URI content", async () => {
+      const result = await hypercertOps.addAttachment({
+        subjects: "at://did:plc:test/org.hypercerts.claim.activity/abc",
         title: "Impact Report",
         content: "https://example.com/report.pdf",
       });
 
-      // Note: In beta.13, evidence was renamed to attachment
       expect(result.uri).toContain("attachment");
       expect(mockAgent.com.atproto.repo.createRecord).toHaveBeenCalled();
       const call = mockAgent.com.atproto.repo.createRecord.mock.calls[0][0];
-      // Content is now an array in the attachment schema
+
+      // Verify subjects array with StrongRef (includes $type)
+      expect(call.record.subjects).toEqual([
+        {
+          $type: "com.atproto.repo.strongRef",
+          uri: "at://did:plc:test/org.hypercerts.claim.activity/abc",
+          cid: "hypercert-cid",
+        },
+      ]);
+
+      // Verify content array
       expect(call.record.content).toEqual([
         {
           $type: "org.hypercerts.defs#uri",
           uri: "https://example.com/report.pdf",
         },
       ]);
+
+      // Verify collection is attachment
+      expect(call.collection).toBe("org.hypercerts.claim.attachment");
     });
 
-    it("should add evidence to a hypercert with a Blob upload", async () => {
+    it("should add attachment with single subject (StrongRef) and single Blob content", async () => {
       const blob = new Blob(["evidence data"], { type: "application/pdf" });
       mockAgent.com.atproto.repo.uploadBlob.mockResolvedValue({
         success: true,
@@ -1127,17 +1135,26 @@ describe("HypercertOperationsImpl", () => {
         },
       });
 
-      const result = await hypercertOps.addEvidence({
-        subjectUri: "at://did:plc:test/org.hypercerts.claim.record/abc",
+      const result = await hypercertOps.addAttachment({
+        subjects: { uri: "at://did:plc:test/org.hypercerts.claim.activity/abc", cid: "hypercert-cid" },
         title: "Impact Report",
         content: blob,
       });
 
-      // Note: In beta.13, evidence was renamed to attachment
       expect(result.uri).toContain("attachment");
       expect(mockAgent.com.atproto.repo.uploadBlob).toHaveBeenCalled();
       const call = mockAgent.com.atproto.repo.createRecord.mock.calls[0][0];
-      // Content is now an array in the attachment schema
+
+      // Verify subjects array (should use provided StrongRef with $type added)
+      expect(call.record.subjects).toEqual([
+        {
+          $type: "com.atproto.repo.strongRef",
+          uri: "at://did:plc:test/org.hypercerts.claim.activity/abc",
+          cid: "hypercert-cid",
+        },
+      ]);
+
+      // Verify content array with blob
       expect(call.record.content).toEqual([
         {
           $type: "org.hypercerts.defs#smallBlob",
@@ -1146,17 +1163,262 @@ describe("HypercertOperationsImpl", () => {
       ]);
     });
 
-    it("should emit evidenceAdded event", async () => {
-      const handler = vi.fn();
-      hypercertOps.on("evidenceAdded", handler);
+    it("should add attachment with multiple subjects", async () => {
+      // Mock getRecord to return different CIDs for different URIs
+      mockAgent.com.atproto.repo.getRecord.mockImplementation((params) => {
+        const rkey = params.rkey || "";
+        return Promise.resolve({
+          success: true,
+          data: {
+            uri: `at://did:plc:test/org.hypercerts.claim.activity/${rkey}`,
+            cid: `cid-${rkey}`,
+            value: { title: "Test" },
+          },
+        });
+      });
 
-      await hypercertOps.addEvidence({
-        subjectUri: "at://did:plc:test/org.hypercerts.claim.record/abc",
-        title: "Impact Report",
+      const result = await hypercertOps.addAttachment({
+        subjects: [
+          "at://did:plc:test/org.hypercerts.claim.activity/abc",
+          "at://did:plc:test/org.hypercerts.claim.activity/def",
+        ],
+        title: "Multi-subject Attachment",
         content: "https://example.com/report.pdf",
       });
 
-      expect(handler).toHaveBeenCalledWith({ uri: expect.any(String), cid: "evidence-cid" });
+      expect(result.uri).toContain("attachment");
+      const call = mockAgent.com.atproto.repo.createRecord.mock.calls[0][0];
+
+      // Verify subjects array contains both StrongRefs
+      expect(call.record.subjects).toHaveLength(2);
+      expect(call.record.subjects[0].uri).toContain("abc");
+      expect(call.record.subjects[1].uri).toContain("def");
+    });
+
+    it("should add attachment with multiple content items (mixed URIs and Blobs)", async () => {
+      const blob = new Blob(["evidence data"], { type: "application/pdf" });
+      mockAgent.com.atproto.repo.uploadBlob.mockResolvedValue({
+        success: true,
+        data: {
+          blob: { ref: { $link: "blob-cid" }, mimeType: "application/pdf", size: 100 },
+        },
+      });
+
+      const result = await hypercertOps.addAttachment({
+        subjects: "at://did:plc:test/org.hypercerts.claim.activity/abc",
+        title: "Mixed Content Attachment",
+        content: ["https://example.com/report.pdf", blob],
+      });
+
+      expect(result.uri).toContain("attachment");
+      expect(mockAgent.com.atproto.repo.uploadBlob).toHaveBeenCalled();
+      const call = mockAgent.com.atproto.repo.createRecord.mock.calls[0][0];
+
+      // Verify content array contains both URI and blob
+      expect(call.record.content).toHaveLength(2);
+      expect(call.record.content[0]).toEqual({
+        $type: "org.hypercerts.defs#uri",
+        uri: "https://example.com/report.pdf",
+      });
+      expect(call.record.content[1]).toEqual({
+        $type: "org.hypercerts.defs#smallBlob",
+        blob: { ref: { $link: "blob-cid" }, mimeType: "application/pdf", size: 100 },
+      });
+    });
+
+    it("should add attachment with contentType", async () => {
+      const result = await hypercertOps.addAttachment({
+        subjects: "at://did:plc:test/org.hypercerts.claim.activity/abc",
+        title: "Image Attachment",
+        content: "https://example.com/image.png",
+        contentType: "image",
+      });
+
+      expect(result.uri).toContain("attachment");
+      const call = mockAgent.com.atproto.repo.createRecord.mock.calls[0][0];
+
+      // Verify contentType is included
+      expect(call.record.contentType).toBe("image");
+    });
+
+    it("should add attachment with location (StrongRef)", async () => {
+      const result = await hypercertOps.addAttachment({
+        subjects: "at://did:plc:test/org.hypercerts.claim.activity/abc",
+        title: "Location-based Attachment",
+        content: "https://example.com/report.pdf",
+        location: { uri: "at://did:plc:test/app.certified.location/loc123", cid: "location-cid" },
+      });
+
+      expect(result.uri).toContain("attachment");
+      const call = mockAgent.com.atproto.repo.createRecord.mock.calls[0][0];
+
+      // Verify location is included as StrongRef (with $type field)
+      expect(call.record.location).toEqual({
+        $type: "com.atproto.repo.strongRef",
+        uri: "at://did:plc:test/app.certified.location/loc123",
+        cid: "location-cid",
+      });
+    });
+
+    it("should add attachment with location (URI string)", async () => {
+      // Mock getRecord for location lookup
+      const locationGetRecord = vi.fn().mockResolvedValue({
+        success: true,
+        data: {
+          uri: "at://did:plc:test/app.certified.location/loc123",
+          cid: "location-cid-fetched",
+          value: { name: "Test Location" },
+        },
+      });
+      mockAgent.com.atproto.repo.getRecord.mockImplementation((params) => {
+        if (params.collection === "app.certified.location") {
+          return locationGetRecord(params);
+        }
+        return Promise.resolve({
+          success: true,
+          data: {
+            uri: "at://did:plc:test/org.hypercerts.claim.activity/abc",
+            cid: "hypercert-cid",
+            value: { title: "Test" },
+          },
+        });
+      });
+
+      const result = await hypercertOps.addAttachment({
+        subjects: "at://did:plc:test/org.hypercerts.claim.activity/abc",
+        title: "Location-based Attachment",
+        content: "https://example.com/report.pdf",
+        location: "at://did:plc:test/app.certified.location/loc123",
+      });
+
+      expect(result.uri).toContain("attachment");
+      const call = mockAgent.com.atproto.repo.createRecord.mock.calls[0][0];
+
+      // Verify location StrongRef was created from URI (with $type field)
+      expect(call.record.location).toEqual({
+        $type: "com.atproto.repo.strongRef",
+        uri: "at://did:plc:test/app.certified.location/loc123",
+        cid: "location-cid-fetched",
+      });
+    });
+
+    it("should add attachment with location (inline object)", async () => {
+      // Mock createRecord for location creation
+      mockAgent.com.atproto.repo.createRecord.mockImplementation((params) => {
+        if (params.collection === "app.certified.location") {
+          return Promise.resolve({
+            success: true,
+            data: { uri: "at://did:plc:test/app.certified.location/new123", cid: "new-location-cid" },
+          });
+        }
+        // For attachment creation
+        if (params.collection === "org.hypercerts.claim.attachment") {
+          return Promise.resolve({
+            success: true,
+            data: { uri: "at://did:plc:test/org.hypercerts.claim.attachment/xyz", cid: "attachment-cid" },
+          });
+        }
+        // Default fallback
+        return Promise.resolve({
+          success: true,
+          data: { uri: "at://did:plc:test/unknown/123", cid: "unknown-cid" },
+        });
+      });
+
+      const result = await hypercertOps.addAttachment({
+        subjects: "at://did:plc:test/org.hypercerts.claim.activity/abc",
+        title: "Location-based Attachment",
+        content: "https://example.com/report.pdf",
+        location: {
+          lpVersion: "1.0.0",
+          srs: "EPSG:4326",
+          locationType: "coordinate-decimal",
+          location: "https://location-uri.com",
+          name: "San Francisco",
+        },
+      });
+
+      expect(result.uri).toContain("attachment");
+      const attachmentCall = mockAgent.com.atproto.repo.createRecord.mock.calls.find(
+        (call) => call[0].collection === "org.hypercerts.claim.attachment",
+      );
+
+      // Verify location was created and StrongRef was added (without $type in return from createLocationRecord)
+      expect(attachmentCall?.[0].record.location).toEqual({
+        uri: "at://did:plc:test/app.certified.location/new123",
+        cid: "new-location-cid",
+      });
+    });
+
+    it("should add attachment with rich text facets", async () => {
+      const shortDescriptionFacets = [
+        {
+          index: { byteStart: 0, byteEnd: 6 },
+          features: [{ $type: "app.bsky.richtext.facet#mention" as const, did: "did:plc:alice" as const }],
+        },
+      ];
+      const descriptionFacets = [
+        {
+          index: { byteStart: 0, byteEnd: 20 },
+          features: [{ $type: "app.bsky.richtext.facet#link" as const, uri: "https://example.com" as const }],
+        },
+      ];
+
+      const result = await hypercertOps.addAttachment({
+        subjects: "at://did:plc:test/org.hypercerts.claim.activity/abc",
+        title: "Attachment with Facets",
+        shortDescription: "@alice check this",
+        description: "https://example.com",
+        content: "https://example.com/report.pdf",
+        shortDescriptionFacets,
+        descriptionFacets,
+      });
+
+      expect(result.uri).toContain("attachment");
+      const call = mockAgent.com.atproto.repo.createRecord.mock.calls[0][0];
+
+      // Verify facets are included
+      expect(call.record.shortDescriptionFacets).toEqual(shortDescriptionFacets);
+      expect(call.record.descriptionFacets).toEqual(descriptionFacets);
+    });
+
+    it("should not include removed fields (relationType, contributors, locations)", async () => {
+      const result = await hypercertOps.addAttachment({
+        subjects: "at://did:plc:test/org.hypercerts.claim.activity/abc",
+        title: "Clean Attachment",
+        content: "https://example.com/report.pdf",
+      });
+
+      expect(result.uri).toContain("attachment");
+      const call = mockAgent.com.atproto.repo.createRecord.mock.calls[0][0];
+
+      // Verify removed fields are not present
+      expect(call.record.relationType).toBeUndefined();
+      expect(call.record.contributors).toBeUndefined();
+      expect(call.record.locations).toBeUndefined();
+    });
+
+    it("should throw ValidationError when content is missing", async () => {
+      await expect(
+        hypercertOps.addAttachment({
+          subjects: "at://did:plc:test/org.hypercerts.claim.activity/abc",
+          title: "Invalid Attachment",
+          // @ts-expect-error - testing missing required field
+          content: undefined,
+        }),
+      ).rejects.toThrow(ValidationError);
+    });
+
+    it("should throw NetworkError when subject fetch fails", async () => {
+      mockAgent.com.atproto.repo.getRecord.mockRejectedValue(new Error("Network error"));
+
+      await expect(
+        hypercertOps.addAttachment({
+          subjects: "at://did:plc:test/org.hypercerts.claim.activity/abc",
+          title: "Attachment",
+          content: "https://example.com/report.pdf",
+        }),
+      ).rejects.toThrow(NetworkError);
     });
   });
 

--- a/packages/sdk-core/tests/repository/Repository.test.ts
+++ b/packages/sdk-core/tests/repository/Repository.test.ts
@@ -94,7 +94,7 @@ describe("Repository", () => {
       expect(typeof hypercerts.list).toBe("function");
       expect(typeof hypercerts.delete).toBe("function");
       expect(typeof hypercerts.attachLocation).toBe("function");
-      expect(typeof hypercerts.addEvidence).toBe("function");
+      expect(typeof hypercerts.addAttachment).toBe("function");
       expect(typeof hypercerts.addContribution).toBe("function");
     });
   });


### PR DESCRIPTION
## Summary
Rename evidence records to attachments throughout the SDK to match lexicon updates in beta.13.

**Breaking Changes:**
- `addEvidence()` → `addAttachment()`
- `CreateHypercertEvidenceParams` → `CreateAttachmentParams` 
- `evidenceUris` → `attachmentUris` in create results
- `evidenceAdded` → `attachmentAdded` event
- Evidence type exports replaced with Attachment equivalents

**Key Updates:**
- Attachment schema now uses `subjects` (array) instead of `subject` (single)
- `content` is now required and accepts arrays
- Removed deprecated fields: `relationType`, `contributors`, `locations`
- Comprehensive test coverage for new attachment API
- Backward compatibility maintained through type aliases

This aligns the SDK with the latest lexicon definitions and prepares for the beta.13 release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * Renamed addEvidence → addAttachment; evidenceUris → attachmentUris; evidenceAdded → attachmentAdded
  * subject/subjectUri consolidated to subjects (now supports arrays); content is required and normalized to an array of URI/Blob refs
  * Removed schema fields: relationType, contributors, locations

* **New Types**
  * Added CreateAttachmentParams, UpdateAttachmentParams, AttachmentParams; HypercertEvidence removed (use HypercertAttachment)

* **Tests & Docs**
  * Tests and docs updated to reflect attachment terminology and examples

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->