### PR TITLE
feat(sdk-core): auto-detect PDS URL from OAuth session

### DIFF
--- a/.changeset/auto-detect-pds-from-session.md
+++ b/.changeset/auto-detect-pds-from-session.md
@@ -1,0 +1,39 @@
+---
+"@hypercerts-org/sdk-core": minor
+---
+
+Auto-detect user's PDS URL from OAuth session instead of requiring static configuration
+
+**Breaking Changes:**
+
+- `servers.pds` config option has been removed. The user's PDS URL is now automatically detected from the OAuth
+  session's token info (`tokenInfo.aud`) during `callback()` and `restoreSession()`. This means the SDK correctly routes
+  operations to each user's actual PDS regardless of which server they're hosted on.
+- A new `handleResolver` config option replaces `servers.pds` for its handle resolution role during OAuth authorization.
+  This is optional — if omitted, DNS-based resolution is used.
+- `getAccountEmail()` no longer requires `servers.pds` to be configured, since it uses the session's fetch handler which
+  internally routes to the correct PDS.
+- `sdk.repository()` is now async (returns `Promise<Repository>`). On cache miss it automatically resolves the PDS from
+  the session's token info, so callers no longer need to manually call `resolveSessionPds()` first.
+
+**New APIs:**
+
+- `sdk.resolveSessionPds(session)` — Manually resolve and cache a session's PDS URL. Useful for pre-warming the cache or
+  for sessions created outside the SDK's auth flow.
+
+**Migration:**
+
+```typescript
+// Before
+const sdk = createATProtoSDK({
+  oauth: { ... },
+  servers: { pds: "https://bsky.social", sds: "https://sds.example.com" },
+});
+
+// After
+const sdk = createATProtoSDK({
+  oauth: { ... },
+  handleResolver: "https://bsky.social", // optional, for handle resolution only
+  servers: { sds: "https://sds.example.com" },
+});
+```

--- a/CERTS_SDK.md
+++ b/CERTS_SDK.md
@@ -53,7 +53,7 @@ Host a `client-metadata.json` file at a public URL (e.g., `https://your-app.com/
 # .env.local
 NEXT_PUBLIC_OAUTH_CLIENT_ID=https://your-app.com/client-metadata.json
 NEXT_PUBLIC_OAUTH_REDIRECT_URI=https://your-app.com/callback
-NEXT_PUBLIC_PDS_URL=https://bsky.social
+NEXT_PUBLIC_HANDLE_RESOLVER_URL=https://bsky.social
 NEXT_PUBLIC_SDS_URL=https://sds.hypercerts.org
 JWK_PRIVATE_KEY={"kty":"EC","crv":"P-256",...}
 ```
@@ -86,8 +86,9 @@ export const atproto = createATProtoReact({
       redirectUri: process.env.NEXT_PUBLIC_OAUTH_REDIRECT_URI!,
       scope: "atproto transition:generic",
     },
+    // Optional: URL for handle resolution during OAuth (defaults to DNS-based resolution)
+    handleResolver: process.env.NEXT_PUBLIC_HANDLE_RESOLVER_URL || "https://bsky.social",
     servers: {
-      pds: process.env.NEXT_PUBLIC_PDS_URL || "https://bsky.social",
       sds: process.env.NEXT_PUBLIC_SDS_URL,
     },
   },
@@ -565,8 +566,8 @@ const sdk = new ATProtoSDK({
     jwksUri: `${process.env.NEXT_PUBLIC_APP_URL}/.well-known/jwks.json`,
     jwkPrivate: process.env.JWK_PRIVATE_KEY!,
   },
+  handleResolver: process.env.NEXT_PUBLIC_HANDLE_RESOLVER_URL || "https://bsky.social",
   servers: {
-    pds: process.env.NEXT_PUBLIC_PDS_URL || "https://bsky.social",
     sds: process.env.NEXT_PUBLIC_SDS_URL,
   },
 });
@@ -673,8 +674,8 @@ export const atproto = createATProtoReact({
       redirectUri: process.env.NEXT_PUBLIC_OAUTH_REDIRECT_URI!,
       scope: "atproto transition:generic",
     },
+    handleResolver: process.env.NEXT_PUBLIC_HANDLE_RESOLVER_URL || "https://bsky.social",
     servers: {
-      pds: process.env.NEXT_PUBLIC_PDS_URL || "https://bsky.social",
       sds: process.env.NEXT_PUBLIC_SDS_URL,
     },
   },

--- a/packages/sdk-core/README.md
+++ b/packages/sdk-core/README.md
@@ -20,11 +20,9 @@ const sdk = createATProtoSDK({
     jwksUri: "https://your-app.com/jwks.json",
     jwkPrivate: process.env.ATPROTO_JWK_PRIVATE!,
   },
-  // set up with your pds url.
-  // entryway doesn't work for this. Has to be a PDS URL.
-  servers: {
-    pds: "https://pds-eu-west4.test.certified.app",
-  },
+  // Optional: URL for handle resolution during OAuth.
+  // If omitted, DNS-based resolution is used.
+  handleResolver: "https://pds-eu-west4.test.certified.app",
 });
 
 // 2. Authenticate user
@@ -80,10 +78,8 @@ const sdk = createATProtoSDK({
     // Optional: suppress warnings
     developmentMode: true,
   },
-  servers: {
-    // Point to local PDS for testing
-    pds: "http://localhost:2583",
-  },
+  // Optional: handle resolver for local testing
+  handleResolver: "http://localhost:2583",
   logger: console, // Enable debug logging
 });
 
@@ -155,17 +151,17 @@ The SDK supports two types of AT Protocol servers:
 - **Purpose**: User's own data storage (e.g., Bluesky)
 - **Use case**: Individual hypercerts, personal records
 - **Features**: Profile management, basic CRUD operations
-- **Example**: `bsky.social`, any Bluesky PDS
+- **Auto-detected**: The SDK automatically discovers the user's PDS from the OAuth session -- no configuration needed
 
 #### Shared Data Server (SDS)
 
 - **Purpose**: Collaborative data storage with access control
 - **Use case**: Organization hypercerts, team collaboration
 - **Features**: Organizations, multi-user access, role-based permissions
-- **Example**: `sds.hypercerts.org`
+- **Configured via**: `servers.sds` in SDK config
 
 ```typescript
-// Connect to user's PDS (default)
+// Connect to user's PDS (default) -- auto-detected from session
 const pdsRepo = sdk.repository(session);
 await pdsRepo.hypercerts.create({ ... }); // Creates in user's PDS
 
@@ -179,6 +175,20 @@ const orgRepo = sdsRepo.repo(orgs.organizations[0].did);
 await orgRepo.hypercerts.list(); // Queries organization's hypercerts on SDS
 ```
 
+#### How PDS Auto-Detection Works
+
+The SDK automatically discovers each user's PDS URL from their OAuth session. You do not need to configure a PDS URL.
+
+1. **During authentication** (`callback()` or `restoreSession()`), the SDK extracts the user's PDS URL from the OAuth
+   token's `aud` field, which is resolved from the user's DID Document.
+
+2. **When creating a repository** (`sdk.repository(session)`), the SDK uses the cached PDS URL for that session's DID.
+
+3. **For sessions created outside the SDK**, you can manually resolve the PDS:
+   ```typescript
+   await sdk.resolveSessionPds(session);
+   ```
+
 #### How Repository Routing Works
 
 The SDK uses a `ConfigurableAgent` to route requests to different servers while maintaining your OAuth authentication:
@@ -186,13 +196,13 @@ The SDK uses a `ConfigurableAgent` to route requests to different servers while 
 1. **Initial Repository Creation**
 
    ```typescript
-   // User authenticates (OAuth session knows user's PDS)
+   // User authenticates -- PDS URL is automatically cached from the session
    const session = await sdk.callback(params);
 
-   // Create PDS repository - routes to user's PDS
+   // Create PDS repository -- routes to user's auto-detected PDS
    const pdsRepo = sdk.repository(session);
 
-   // Create SDS repository - routes to SDS server
+   // Create SDS repository -- routes to configured SDS server
    const sdsRepo = sdk.repository(session, { server: "sds" });
    ```
 
@@ -206,13 +216,14 @@ The SDK uses a `ConfigurableAgent` to route requests to different servers while 
    const orgRepo = userSdsRepo.repo("did:plc:org-did");
 
    // All operations on orgRepo still route to SDS, not user's PDS
-   await orgRepo.hypercerts.list(); // ✅ Queries SDS
-   await orgRepo.collaborators.list(); // ✅ Queries SDS
+   await orgRepo.hypercerts.list(); // Queries SDS
+   await orgRepo.collaborators.list(); // Queries SDS
    ```
 
 3. **Key Implementation Details**
    - Each Repository uses a `ConfigurableAgent` that wraps your OAuth session's fetch handler
    - The agent routes all requests to the specified server URL (PDS, SDS, or custom)
+   - The user's PDS URL is auto-detected from the OAuth session's token info (`tokenInfo.aud`)
    - When you call `.repo(did)`, a new Repository is created with the same server configuration
    - Your OAuth session provides authentication (DPoP, access tokens), while the agent handles routing
    - This enables simultaneous connections to multiple servers with one authentication session
@@ -220,7 +231,7 @@ The SDK uses a `ConfigurableAgent` to route requests to different servers while 
 #### Common Patterns
 
 ```typescript
-// Pattern 1: Personal hypercerts on PDS
+// Pattern 1: Personal hypercerts on PDS (auto-detected)
 const myRepo = sdk.repository(session);
 await myRepo.hypercerts.create({ title: "My Personal Impact" });
 

--- a/packages/sdk-core/src/auth/OAuthClient.ts
+++ b/packages/sdk-core/src/auth/OAuthClient.ts
@@ -52,7 +52,7 @@ interface AuthorizeOptions {
  *     jwksUri: "https://my-app.com/.well-known/jwks.json",
  *     jwkPrivate: process.env.JWK_PRIVATE_KEY!,
  *   },
- *   servers: { pds: "https://bsky.social" },
+ *   handleResolver: "https://pds-eu-west4.test.certified.app",
  * });
  *
  * // Start authorization
@@ -146,7 +146,7 @@ export class OAuthClient {
       keyset,
       stateStore: this.createStateStoreAdapter(stateStore),
       sessionStore: this.createSessionStoreAdapter(sessionStore),
-      handleResolver: this.config.servers?.pds,
+      handleResolver: this.config.handleResolver,
       fetch: this.config.fetch ?? fetchWithTimeout,
     });
 

--- a/packages/sdk-core/src/core/SDK.ts
+++ b/packages/sdk-core/src/core/SDK.ts
@@ -84,8 +84,8 @@ export interface AuthorizeOptions {
  *     jwksUri: "https://my-app.com/.well-known/jwks.json",
  *     jwkPrivate: process.env.JWK_PRIVATE_KEY!,
  *   },
+ *   handleResolver: "https://bsky.social",
  *   servers: {
- *     pds: "https://bsky.social",
  *     sds: "https://sds.hypercerts.org",
  *   },
  * });
@@ -119,6 +119,8 @@ export class ATProtoSDK {
   private config: ATProtoSDKConfig;
   private logger?: ATProtoSDKConfig["logger"];
   private lexiconRegistry: LexiconRegistry;
+  /** Cache of session DID → PDS URL, populated during callback/restoreSession */
+  private sessionPdsMap = new Map<string, string>();
 
   /**
    * Creates a new ATProto SDK instance.
@@ -142,7 +144,7 @@ export class ATProtoSDK {
    *     jwksUri: "https://my-app.com/.well-known/jwks.json",
    *     jwkPrivate: privateKeyJwk,
    *   },
-   *   servers: { pds: "https://bsky.social" },
+   *   handleResolver: "https://pds-eu-west4.test.certified.app",
    * });
    * ```
    */
@@ -243,7 +245,19 @@ export class ATProtoSDK {
    * ```
    */
   async callback(params: URLSearchParams): Promise<Session> {
-    return this.oauthClient.callback(params);
+    const session = await this.oauthClient.callback(params);
+
+    // Cache the user's actual PDS URL from the token
+    try {
+      const tokenInfo = await session.getTokenInfo();
+      if (tokenInfo.aud) {
+        this.sessionPdsMap.set(session.did, tokenInfo.aud);
+      }
+    } catch {
+      this.logger?.warn?.("Could not resolve PDS URL from session token during callback");
+    }
+
+    return session;
   }
 
   /**
@@ -279,7 +293,21 @@ export class ATProtoSDK {
       throw new ValidationError("DID is required");
     }
 
-    return this.oauthClient.restore(did.trim());
+    const session = await this.oauthClient.restore(did.trim());
+
+    if (session) {
+      // Cache the user's actual PDS URL from the token
+      try {
+        const tokenInfo = await session.getTokenInfo();
+        if (tokenInfo.aud) {
+          this.sessionPdsMap.set(session.did, tokenInfo.aud);
+        }
+      } catch {
+        this.logger?.warn?.("Could not resolve PDS URL from session token during restore");
+      }
+    }
+
+    return session;
   }
 
   /**
@@ -358,14 +386,9 @@ export class ATProtoSDK {
     }
 
     try {
-      // Determine PDS URL from session or config
-      const pdsUrl = this.config.servers?.pds;
-      if (!pdsUrl) {
-        throw new ValidationError("PDS server URL not configured");
-      }
-
       // Call com.atproto.server.getSession endpoint using session's fetchHandler
-      // which automatically includes proper authorization with DPoP
+      // which automatically includes proper authorization with DPoP.
+      // The session internally routes this to the user's actual PDS via tokenSet.aud.
       const response = await session.fetchHandler("/xrpc/com.atproto.server.getSession", {
         method: "GET",
         headers: {
@@ -440,7 +463,7 @@ export class ATProtoSDK {
    * });
    * ```
    */
-  repository(session: Session, options?: RepositoryOptions): Repository {
+  async repository(session: Session, options?: RepositoryOptions): Promise<Repository> {
     if (!session) {
       throw new ValidationError("Session is required");
     }
@@ -462,11 +485,22 @@ export class ATProtoSDK {
       serverUrl = this.config.servers.sds;
       isSDS = true;
     } else if (options?.server === "pds" || !options?.server) {
-      // Use configured PDS (default)
-      if (!this.config.servers?.pds) {
-        throw new ValidationError("PDS server URL not configured");
+      // Auto-detect PDS from cached session info
+      const did = session.did || session.sub;
+      let cachedPds = this.sessionPdsMap.get(did);
+
+      if (!cachedPds) {
+        // Try to resolve on the fly before giving up
+        try {
+          cachedPds = await this.resolveSessionPds(session);
+        } catch {
+          throw new ValidationError(
+            "Could not determine PDS URL. Ensure the session has valid token info, " +
+              "or was created via SDK auth methods (callback/restoreSession).",
+          );
+        }
       }
-      serverUrl = this.config.servers.pds;
+      serverUrl = cachedPds;
       isSDS = false;
     } else {
       // Custom server string (treat as URL)
@@ -510,12 +544,52 @@ export class ATProtoSDK {
   }
 
   /**
-   * The configured PDS (Personal Data Server) URL.
+   * Resolves and caches the PDS URL from a session's token info.
    *
-   * @returns The PDS URL if configured, otherwise `undefined`
+   * This method is automatically called during `callback()` and `restoreSession()`.
+   * Use it manually if you have a session obtained outside the SDK's auth flow
+   * and need to enable PDS auto-detection for `repository()`.
+   *
+   * @param session - An authenticated OAuth session
+   * @returns The resolved PDS URL
+   * @throws {@link ValidationError} if the PDS URL cannot be determined from the session
+   *
+   * @example
+   * ```typescript
+   * // For sessions created outside the SDK auth flow
+   * const pdsUrl = await sdk.resolveSessionPds(session);
+   * const repo = sdk.repository(session); // Now works with auto-detected PDS
+   * ```
+   */
+  async resolveSessionPds(session: Session): Promise<string> {
+    try {
+      const tokenInfo = await session.getTokenInfo();
+      if (tokenInfo.aud) {
+        this.sessionPdsMap.set(session.did, tokenInfo.aud);
+        return tokenInfo.aud;
+      }
+      throw new ValidationError("Could not determine PDS URL from session token info");
+    } catch (error) {
+      if (error instanceof ValidationError) {
+        throw error;
+      }
+      throw new ValidationError("Could not determine PDS URL from session token info", error);
+    }
+  }
+
+  /**
+   * Gets the cached PDS URL for a specific DID, if available.
+   *
+   * @param did - The user's DID
+   * @returns The cached PDS URL, or `undefined` if not cached
+   *
+   * @deprecated Use `resolveSessionPds()` to resolve and cache PDS URLs.
+   * This getter is provided for backward compatibility with sdk-react.
    */
   get pdsUrl(): string | undefined {
-    return this.config.servers?.pds;
+    // Return the first cached PDS URL for backward compat with sdk-react
+    const firstEntry = this.sessionPdsMap.values().next();
+    return firstEntry.done ? undefined : firstEntry.value;
   }
 
   /**
@@ -542,7 +616,7 @@ export class ATProtoSDK {
  *
  * const sdk = createATProtoSDK({
  *   oauth: { ... },
- *   servers: { pds: "https://bsky.social" },
+ *   handleResolver: "https://bsky.social",
  * });
  * ```
  */

--- a/packages/sdk-core/src/core/config.ts
+++ b/packages/sdk-core/src/core/config.ts
@@ -160,26 +160,11 @@ export const OAuthConfigSchema = z.object({
  * Zod schema for server URL configuration.
  *
  * @remarks
- * At least one server (PDS or SDS) should be configured for the SDK to be useful.
+ * Configure SDS here for collaborative operations.
+ * PDS URLs are auto-detected from the user's OAuth session and do not need configuration.
  * For local development, HTTP loopback URLs are allowed.
  */
 export const ServerConfigSchema = z.object({
-  /**
-   * Personal Data Server URL - the user's own AT Protocol server.
-   * This is the primary server for user data operations.
-   *
-   * @example Production
-   * ```typescript
-   * pds: "https://bsky.social"
-   * ```
-   *
-   * @example Local development
-   * ```typescript
-   * pds: "http://localhost:2583"
-   * ```
-   */
-  pds: urlOrLoopback.optional(),
-
   /**
    * Shared Data Server URL - for collaborative data storage.
    * Required for collaborator and organization operations.
@@ -227,6 +212,19 @@ export const TimeoutConfigSchema = z.object({
  */
 export const ATProtoSDKConfigSchema = z.object({
   oauth: OAuthConfigSchema,
+  /**
+   * URL string used for resolving AT Protocol handles to DIDs
+   * during the OAuth authorization flow. This can be any server that speaks
+   * the `com.atproto.identity.resolveHandle` XRPC method.
+   *
+   * If not provided, the `@atproto` library falls back to DNS-based handle resolution.
+   *
+   * @example
+   * ```typescript
+   * handleResolver: "https://pds-eu-west4.test.certified.app"
+   * ```
+   */
+  handleResolver: urlOrLoopback.optional(),
   servers: ServerConfigSchema.optional(),
   timeouts: TimeoutConfigSchema.optional(),
 });
@@ -247,9 +245,6 @@ export const ATProtoSDKConfigSchema = z.object({
  *     jwksUri: "https://my-app.com/.well-known/jwks.json",
  *     jwkPrivate: process.env.JWK_PRIVATE_KEY!,
  *   },
- *   servers: {
- *     pds: "https://bsky.social",
- *   },
  * };
  * ```
  *
@@ -257,8 +252,8 @@ export const ATProtoSDKConfigSchema = z.object({
  * ```typescript
  * const config: ATProtoSDKConfig = {
  *   oauth: { ... },
+ *   handleResolver: "https://bsky.social",
  *   servers: {
- *     pds: "https://bsky.social",
  *     sds: "https://sds.hypercerts.org",
  *   },
  *   storage: {
@@ -285,10 +280,29 @@ export interface ATProtoSDKConfig {
   oauth: z.infer<typeof OAuthConfigSchema>;
 
   /**
-   * Server URLs for PDS and SDS connections.
+   * URL string used for resolving AT Protocol handles to DIDs during the OAuth
+   * authorization flow. This can be any server that speaks the
+   * `com.atproto.identity.resolveHandle` XRPC method.
    *
-   * - **PDS**: Personal Data Server - user's own data storage
+   * If not provided, the `@atproto` library falls back to DNS-based handle resolution.
+   *
+   * Note: This is NOT the user's PDS URL. The user's PDS is auto-detected from
+   * the OAuth session during `callback()` and `restoreSession()`.
+   *
+   * @example
+   * ```typescript
+   * handleResolver: "https://pds-eu-west4.test.certified.app"
+   * ```
+   */
+  handleResolver?: string;
+
+  /**
+   * Server URLs for SDS connections.
+   *
    * - **SDS**: Shared Data Server - collaborative storage with access control
+   *
+   * Note: PDS (Personal Data Server) URLs are auto-detected from the user's
+   * OAuth session and do not need to be configured.
    */
   servers?: z.infer<typeof ServerConfigSchema>;
 

--- a/packages/sdk-core/src/testing/mocks.ts
+++ b/packages/sdk-core/src/testing/mocks.ts
@@ -69,6 +69,14 @@ export function createMockSession(overrides: Partial<Session> = {}): Session {
         headers: { "Content-Type": "application/json" },
       });
     },
+    getTokenInfo: async () => ({
+      expiresAt: new Date(Date.now() + 3600 * 1000),
+      expired: false,
+      scope: "atproto" as const,
+      iss: "https://bsky.social",
+      aud: "https://bsky.social",
+      sub: "did:plc:test123",
+    }),
     ...overrides,
   } as unknown as Session;
 
@@ -102,12 +110,10 @@ export function createMockSession(overrides: Partial<Session> = {}): Session {
  * const sdk = new ATProtoSDK(config);
  * ```
  *
- * @example With custom PDS
+ * @example With custom handle resolver
  * ```typescript
  * const config = createTestConfig({
- *   servers: {
- *     pds: "https://custom-pds.example.com",
- *   },
+ *   handleResolver: "https://custom-resolver.example.com",
  * });
  * ```
  *
@@ -133,8 +139,8 @@ export function createTestConfig(overrides: Partial<ATProtoSDKConfig> = {}): ATP
         d: "test",
       }),
     },
+    handleResolver: "https://pds-eu-west4.test.certified.app",
     servers: {
-      pds: "https://bsky.social",
       sds: "https://sds.example.com",
     },
     ...overrides,

--- a/packages/sdk-core/tests/core/SDK.test.ts
+++ b/packages/sdk-core/tests/core/SDK.test.ts
@@ -114,13 +114,28 @@ describe("ATProtoSDK", () => {
       await expect(sdk.getAccountEmail(null as any)).rejects.toThrow(ValidationError);
     });
 
-    it("should throw ValidationError when PDS not configured", async () => {
-      const configWithoutPds = await createTestConfigAsync();
-      delete configWithoutPds.servers;
-      const sdk = new ATProtoSDK(configWithoutPds);
-      const mockSession = createMockSession();
-      await expect(sdk.getAccountEmail(mockSession)).rejects.toThrow(ValidationError);
-      await expect(sdk.getAccountEmail(mockSession)).rejects.toThrow("PDS server URL not configured");
+    it("should work without servers.pds configured", async () => {
+      // getAccountEmail uses session.fetchHandler with relative paths,
+      // so it doesn't need servers.pds — the session routes to the correct PDS internally
+      const configWithoutServers = await createTestConfigAsync();
+      delete configWithoutServers.servers;
+      const sdk = new ATProtoSDK(configWithoutServers);
+      const mockSession = createMockSession({
+        fetchHandler: async () =>
+          new Response(
+            JSON.stringify({
+              did: "did:plc:testdid123456789012345678901234567890",
+              handle: "test.bsky.social",
+              email: "test@example.com",
+              emailConfirmed: true,
+            }),
+            { status: 200 },
+          ),
+      });
+
+      const result = await sdk.getAccountEmail(mockSession);
+      expect(result).not.toBeNull();
+      expect(result?.email).toBe("test@example.com");
     });
 
     it("should return email info when permission granted", async () => {
@@ -209,34 +224,164 @@ describe("ATProtoSDK", () => {
   });
 
   describe("repository", () => {
-    it("should throw ValidationError when session is null", () => {
+    it("should throw ValidationError when session is null", async () => {
       const sdk = new ATProtoSDK(config);
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      expect(() => sdk.repository(null as any)).toThrow(ValidationError);
-    });
-
-    it("should throw ValidationError when PDS not configured and no server specified", async () => {
-      const configWithoutServers = await createTestConfigAsync();
-      delete configWithoutServers.servers;
-      const sdk = new ATProtoSDK(configWithoutServers);
-      const mockSession = createMockSession();
-      expect(() => sdk.repository(mockSession)).toThrow(ValidationError);
+      await expect(sdk.repository(null as any)).rejects.toThrow(ValidationError);
     });
 
     it("should throw ValidationError when SDS not configured and server=sds", async () => {
-      const configWithOnlyPds = await createTestConfigAsync();
-      configWithOnlyPds.servers = { pds: "https://pds.example.com" };
-      const sdk = new ATProtoSDK(configWithOnlyPds);
+      const configWithoutSds = await createTestConfigAsync();
+      delete configWithoutSds.servers?.sds;
+      const sdk = new ATProtoSDK(configWithoutSds);
       const mockSession = createMockSession();
-      expect(() => sdk.repository(mockSession, { server: "sds" })).toThrow(ValidationError);
+      await expect(sdk.repository(mockSession, { server: "sds" })).rejects.toThrow(ValidationError);
     });
 
-    it("should create repository with custom serverUrl", () => {
+    it("should create repository with custom serverUrl", async () => {
       const sdk = new ATProtoSDK(config);
       const mockSession = createMockSession();
-      const repo = sdk.repository(mockSession, { serverUrl: "https://custom.server.com" });
+      const repo = await sdk.repository(mockSession, { serverUrl: "https://custom.server.com" });
       expect(repo).toBeDefined();
       expect(repo.getServerUrl()).toBe("https://custom.server.com");
+    });
+
+    it("should auto-detect PDS from session after resolveSessionPds", async () => {
+      // Create SDK without any server config
+      const configWithoutServers = await createTestConfigAsync();
+      delete configWithoutServers.servers;
+      const sdk = new ATProtoSDK(configWithoutServers);
+
+      const mockSession = createMockSession({
+        getTokenInfo: async () => ({
+          expiresAt: new Date(Date.now() + 3600 * 1000),
+          expired: false,
+          scope: "atproto" as const,
+          iss: "https://bsky.social",
+          aud: "https://user-pds.example.com",
+          sub: "did:plc:testdid123456789012345678901234567890" as const,
+        }),
+      });
+
+      // Resolve and cache the PDS URL from the session
+      const pdsUrl = await sdk.resolveSessionPds(mockSession);
+      expect(pdsUrl).toBe("https://user-pds.example.com");
+
+      // Now repository() should work without servers.pds being configured
+      const repo = await sdk.repository(mockSession);
+      expect(repo).toBeDefined();
+      expect(repo.getServerUrl()).toBe("https://user-pds.example.com");
+    });
+
+    it("should auto-resolve PDS on cache miss when session has valid token info", async () => {
+      // Create SDK without any server config — and do NOT call resolveSessionPds
+      const configWithoutServers = await createTestConfigAsync();
+      delete configWithoutServers.servers;
+      const sdk = new ATProtoSDK(configWithoutServers);
+
+      const mockSession = createMockSession({
+        getTokenInfo: async () => ({
+          expiresAt: new Date(Date.now() + 3600 * 1000),
+          expired: false,
+          scope: "atproto" as const,
+          iss: "https://bsky.social",
+          aud: "https://auto-resolved-pds.example.com",
+          sub: "did:plc:testdid123456789012345678901234567890" as const,
+        }),
+      });
+
+      // repository() should auto-resolve the PDS on the fly
+      const repo = await sdk.repository(mockSession);
+      expect(repo).toBeDefined();
+      expect(repo.getServerUrl()).toBe("https://auto-resolved-pds.example.com");
+    });
+
+    it("should throw when session has no valid token info and cache is empty", async () => {
+      // Create SDK without any server config
+      const configWithoutServers = await createTestConfigAsync();
+      delete configWithoutServers.servers;
+      const sdk = new ATProtoSDK(configWithoutServers);
+
+      // Session with getTokenInfo that returns empty aud
+      const mockSession = createMockSession({
+        getTokenInfo: async () => ({
+          expiresAt: new Date(Date.now() + 3600 * 1000),
+          expired: false,
+          scope: "atproto" as const,
+          iss: "https://bsky.social",
+          aud: "",
+          sub: "did:plc:testdid123456789012345678901234567890" as const,
+        }),
+      });
+
+      await expect(sdk.repository(mockSession)).rejects.toThrow(ValidationError);
+    });
+
+    it("should still respect explicit serverUrl regardless of cache", async () => {
+      const sdk = new ATProtoSDK(config);
+      const mockSession = createMockSession();
+
+      // Populate cache with one URL
+      await sdk.resolveSessionPds(mockSession);
+
+      // Pass an explicit serverUrl - should override the cached value
+      const repo = await sdk.repository(mockSession, { serverUrl: "https://explicit.example.com" });
+      expect(repo).toBeDefined();
+      expect(repo.getServerUrl()).toBe("https://explicit.example.com");
+    });
+
+    it("should create repository with server=pds using cached PDS", async () => {
+      const sdk = new ATProtoSDK(config);
+      const mockSession = createMockSession({
+        getTokenInfo: async () => ({
+          expiresAt: new Date(Date.now() + 3600 * 1000),
+          expired: false,
+          scope: "atproto" as const,
+          iss: "https://bsky.social",
+          aud: "https://cached-pds.example.com",
+          sub: "did:plc:testdid123456789012345678901234567890" as const,
+        }),
+      });
+
+      await sdk.resolveSessionPds(mockSession);
+      const repo = await sdk.repository(mockSession, { server: "pds" });
+      expect(repo).toBeDefined();
+      expect(repo.getServerUrl()).toBe("https://cached-pds.example.com");
+    });
+  });
+
+  describe("resolveSessionPds", () => {
+    it("should resolve and cache PDS from session token info", async () => {
+      const sdk = new ATProtoSDK(config);
+      const mockSession = createMockSession({
+        getTokenInfo: async () => ({
+          expiresAt: new Date(Date.now() + 3600 * 1000),
+          expired: false,
+          scope: "atproto" as const,
+          iss: "https://bsky.social",
+          aud: "https://resolved-pds.example.com",
+          sub: "did:plc:testdid123456789012345678901234567890" as const,
+        }),
+      });
+
+      const pdsUrl = await sdk.resolveSessionPds(mockSession);
+      expect(pdsUrl).toBe("https://resolved-pds.example.com");
+    });
+
+    it("should throw when getTokenInfo returns no aud", async () => {
+      const sdk = new ATProtoSDK(config);
+      const mockSession = createMockSession({
+        getTokenInfo: async () => ({
+          expiresAt: new Date(Date.now() + 3600 * 1000),
+          expired: false,
+          scope: "atproto" as const,
+          iss: "https://bsky.social",
+          aud: "",
+          sub: "did:plc:testdid123456789012345678901234567890" as const,
+        }),
+      });
+
+      await expect(sdk.resolveSessionPds(mockSession)).rejects.toThrow(ValidationError);
     });
   });
 

--- a/packages/sdk-core/tests/core/config.test.ts
+++ b/packages/sdk-core/tests/core/config.test.ts
@@ -237,7 +237,7 @@ describe("URL Validation with Loopback Support", () => {
   });
 
   describe("server URLs validation", () => {
-    it("accepts loopback PDS URL", () => {
+    it("accepts loopback SDS URL with handleResolver", () => {
       const config = {
         oauth: {
           clientId: "http://localhost/",
@@ -246,8 +246,9 @@ describe("URL Validation with Loopback Support", () => {
           jwksUri: "http://localhost:3000/jwks.json",
           jwkPrivate: validJWK,
         },
+        handleResolver: "http://localhost:2583",
         servers: {
-          pds: "http://localhost:2583",
+          sds: "http://localhost:2584",
         },
       };
 
@@ -271,7 +272,7 @@ describe("URL Validation with Loopback Support", () => {
       expect(() => ATProtoSDKConfigSchema.parse(config)).not.toThrow();
     });
 
-    it("accepts both loopback PDS and SDS", () => {
+    it("accepts loopback SDS with handleResolver", () => {
       const config = {
         oauth: {
           clientId: "http://localhost/",
@@ -280,8 +281,8 @@ describe("URL Validation with Loopback Support", () => {
           jwksUri: "http://localhost:3000/jwks.json",
           jwkPrivate: validJWK,
         },
+        handleResolver: "http://localhost:2583",
         servers: {
-          pds: "http://localhost:2583",
           sds: "http://127.0.0.1:2584",
         },
       };
@@ -289,7 +290,7 @@ describe("URL Validation with Loopback Support", () => {
       expect(() => ATProtoSDKConfigSchema.parse(config)).not.toThrow();
     });
 
-    it("rejects non-loopback http server URLs", () => {
+    it("rejects non-loopback http SDS URLs", () => {
       const config = {
         oauth: {
           clientId: "https://example.com/",
@@ -299,7 +300,7 @@ describe("URL Validation with Loopback Support", () => {
           jwkPrivate: validJWK,
         },
         servers: {
-          pds: "http://example.com:2583",
+          sds: "http://example.com:2584",
         },
       };
 
@@ -319,8 +320,8 @@ describe("URL Validation with Loopback Support", () => {
           jwksUri: "https://example.com/jwks.json",
           jwkPrivate: validJWK,
         },
+        handleResolver: "https://pds-eu-west4.test.certified.app",
         servers: {
-          pds: "https://bsky.social",
           sds: "https://sds.hypercerts.org",
         },
       };
@@ -390,7 +391,7 @@ describe("URL Validation with Loopback Support", () => {
       expect(() => ATProtoSDKConfigSchema.parse(config)).not.toThrow();
     });
 
-    it("accepts https clientId with loopback for local testing servers", () => {
+    it("accepts https clientId with loopback handleResolver for local testing", () => {
       const config = {
         oauth: {
           clientId: "https://example.com/",
@@ -399,9 +400,7 @@ describe("URL Validation with Loopback Support", () => {
           jwksUri: "https://example.com/jwks.json",
           jwkPrivate: validJWK,
         },
-        servers: {
-          pds: "http://localhost:2583", // Testing against local PDS
-        },
+        handleResolver: "http://localhost:2583", // Testing against local handle resolver
       };
 
       expect(() => ATProtoSDKConfigSchema.parse(config)).not.toThrow();

--- a/packages/sdk-core/tests/utils/fixtures.ts
+++ b/packages/sdk-core/tests/utils/fixtures.ts
@@ -76,8 +76,8 @@ export function createTestConfig(overrides?: Partial<ATProtoSDKConfig>): ATProto
       jwkPrivate: createTestJWKSync(),
       ...overrides?.oauth,
     },
+    handleResolver: overrides?.handleResolver ?? "https://pds-eu-west4.test.certified.app",
     servers: {
-      pds: "https://bsky.social",
       ...overrides?.servers,
     },
     storage: overrides?.storage,
@@ -104,8 +104,8 @@ export async function createTestConfigAsync(overrides?: Partial<ATProtoSDKConfig
       jwkPrivate,
       ...overrides?.oauth,
     },
+    handleResolver: overrides?.handleResolver ?? "https://pds-eu-west4.test.certified.app",
     servers: {
-      pds: "https://bsky.social",
       ...overrides?.servers,
     },
     storage: overrides?.storage,

--- a/packages/sdk-core/tests/utils/repository-fixtures.ts
+++ b/packages/sdk-core/tests/utils/repository-fixtures.ts
@@ -30,7 +30,7 @@ export function createMockSession(overrides?: Partial<Session>): Session {
       expired: false,
       scope: "atproto",
       iss: "https://pds.example.com",
-      aud: "https://example.com/atproto-client-metadata.json",
+      aud: "https://pds.example.com",
       sub: "did:plc:testdid123456789012345678901234567890",
     }),
     signOut: async () => {},

--- a/packages/sdk-react/src/hooks/useRepository.ts
+++ b/packages/sdk-react/src/hooks/useRepository.ts
@@ -120,31 +120,43 @@ export function useRepository(options: UseRepositoryOptions = {}): UseRepository
   });
 
   // Build repository once server is resolved
-  const repository = useMemo((): Repository | null => {
-    if (!session || !serverQuery.data) return null;
+  const repositoryQuery = useQuery({
+    queryKey: atprotoKeys.repository(repoDid ?? "", serverQuery.data?.url ?? ""),
+    queryFn: async (): Promise<Repository | null> => {
+      if (!session || !serverQuery.data) return null;
 
-    try {
-      return sdk.repository(session, {
-        serverUrl: serverQuery.data.url,
-        server: serverQuery.data.type === "sds" ? "sds" : "pds",
-      });
-    } catch {
-      return null;
-    }
-  }, [sdk, session, serverQuery.data]);
+      try {
+        return await sdk.repository(session, {
+          serverUrl: serverQuery.data.url,
+          server: serverQuery.data.type === "sds" ? "sds" : "pds",
+        });
+      } catch {
+        return null;
+      }
+    },
+    enabled: !!session && !!serverQuery.data && authStatus === "authenticated",
+    staleTime: 5 * 60 * 1000, // 5 minutes - repositories are stable
+  });
 
   // Derive status
   const status = useMemo(() => {
     if (authStatus !== "authenticated") return "idle" as const;
-    if (serverQuery.isLoading) return "loading" as const;
-    if (serverQuery.error || !repository) return "error" as const;
+    if (serverQuery.isLoading || repositoryQuery.isLoading) return "loading" as const;
+    if (serverQuery.error || repositoryQuery.error || !repositoryQuery.data) return "error" as const;
     return "ready" as const;
-  }, [authStatus, serverQuery.isLoading, serverQuery.error, repository]);
+  }, [
+    authStatus,
+    serverQuery.isLoading,
+    repositoryQuery.isLoading,
+    serverQuery.error,
+    repositoryQuery.error,
+    repositoryQuery.data,
+  ]);
 
   return {
-    repository,
+    repository: repositoryQuery.data ?? null,
     status,
-    error: serverQuery.error ?? null,
+    error: serverQuery.error ?? repositoryQuery.error ?? null,
     isSDS: serverQuery.data?.type === "sds",
     serverUrl: serverQuery.data?.url ?? null,
   };

--- a/packages/sdk-react/src/queries/keys.ts
+++ b/packages/sdk-react/src/queries/keys.ts
@@ -64,6 +64,20 @@ export const atprotoKeys = {
   server: (did: string) => [...atprotoKeys.servers(), did] as const,
 
   // ─────────────────────────────────────────────
+  // Repository Keys
+  // ─────────────────────────────────────────────
+
+  /**
+   * Key for all repository instances.
+   */
+  repositories: () => [...atprotoKeys.all, "repository"] as const,
+
+  /**
+   * Key for a specific repository instance by DID and server URL.
+   */
+  repository: (did: string, serverUrl: string) => [...atprotoKeys.repositories(), did, serverUrl] as const,
+
+  // ─────────────────────────────────────────────
   // Profile Keys
   // ─────────────────────────────────────────────
 
@@ -172,6 +186,8 @@ export type ATProtoQueryKey =
   | ReturnType<typeof atprotoKeys.sessionByDid>
   | ReturnType<typeof atprotoKeys.servers>
   | ReturnType<typeof atprotoKeys.server>
+  | ReturnType<typeof atprotoKeys.repositories>
+  | ReturnType<typeof atprotoKeys.repository>
   | ReturnType<typeof atprotoKeys.profiles>
   | ReturnType<typeof atprotoKeys.profile>
   | ReturnType<typeof atprotoKeys.organizations>

--- a/packages/sdk-react/src/utils/ssr.ts
+++ b/packages/sdk-react/src/utils/ssr.ts
@@ -83,7 +83,7 @@ export function createSSRHelpers(sdk: ATProtoSDK, queryClient: QueryClient): SSR
             const session = await sdk.restoreSession(did);
             if (!session) return null;
 
-            const repo = sdk.repository(session);
+            const repo = await sdk.repository(session);
             const profile = await repo.profile.get();
 
             return {


### PR DESCRIPTION
## Summary

Closes #75

- Remove `servers.pds` config — the user's PDS is now auto-detected from the OAuth session's `tokenInfo.aud` during `callback()` / `restoreSession()`
- Add `handleResolver` config option (optional) for handle-to-DID resolution during OAuth
- Add `sdk.resolveSessionPds(session)` for manually caching PDS URLs for sessions created outside the SDK auth flow
- Remove unnecessary `servers.pds` gate from `getAccountEmail()`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * PDS URL is auto-detected from OAuth session tokens; repository access is now asynchronous.
  * Added API to manually resolve and cache a session's PDS for pre-warming/non-flow sessions.
  * Email lookup works without a configured PDS; repo routing follows session-derived PDS.

* **Breaking Changes**
  * Static PDS server config removed; optional handle resolver replaces the prior PDS config/env var.
  * Initialization and session restore/callback flows now auto-route to PDS via session token info.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->