### PR TITLE
chore(sdk-core): enhance RichText changeset with versioning note and usage examples

### DIFF
--- a/.changeset/add-richtext-utility.md
+++ b/.changeset/add-richtext-utility.md
@@ -4,9 +4,24 @@
 
 Add RichText utility functions for auto-detecting facets from text
 
+**0.x Versioning Note:** This is a non-breaking addition. No existing APIs are modified or removed.
+
 New utility functions to simplify creating rich text facets:
 
 - `createFacetsFromText(text, agent?)` - async function that auto-detects URLs, hashtags, and @mentions. If an agent is
-  provided, resolves mentions to DIDs.
-- `createFacetsFromTextSync(text)` - sync function for fast detection without mention resolution
+  provided, resolves mentions to DIDs; otherwise mentions use the handle string as the DID.
+- `createFacetsFromTextSync(text)` - sync function for fast detection without mention resolution (mentions use handle as
+  DID)
 - Re-exports `RichText` class from `@atproto/api` for advanced use cases
+
+**Usage:**
+
+```typescript
+import { createFacetsFromText, createFacetsFromTextSync } from "@hypercerts-org/sdk-core";
+
+// Sync (no DID resolution)
+const facets = createFacetsFromTextSync("Check out #hypercerts by @alice");
+
+// Async with DID resolution (requires authenticated agent)
+const facets = await createFacetsFromText("Check out #hypercerts by @alice", agent);
+```

--- a/.changeset/add-richtext-utility.md
+++ b/.changeset/add-richtext-utility.md
@@ -20,8 +20,8 @@ New utility functions to simplify creating rich text facets:
 import { createFacetsFromText, createFacetsFromTextSync } from "@hypercerts-org/sdk-core";
 
 // Sync (no DID resolution)
-const facets = createFacetsFromTextSync("Check out #hypercerts by @alice");
+const facetsSync = createFacetsFromTextSync("Check out #hypercerts by @alice");
 
 // Async with DID resolution (requires authenticated agent)
-const facets = await createFacetsFromText("Check out #hypercerts by @alice", agent);
+const facetsAsync = await createFacetsFromText("Check out #hypercerts by @alice", agent);
 ```


### PR DESCRIPTION
## Summary

- Adds a 0.x versioning note clarifying this is a non-breaking addition
- Corrects the description of unresolved mention handling (handle string used as DID, not left unresolved)
- Adds usage examples for both `createFacetsFromText` and `createFacetsFromTextSync`

## Details

This cherry-picks a single commit (`c175665`) from the `banner` branch that improves the `add-richtext-utility.md` changeset documentation. It is entirely unrelated to the DID validation and blob ref changes on that branch and can be merged independently.

Only `.changeset/add-richtext-utility.md` is modified — no source code changes.

Extracted from #123.