### PR TITLE
docs: add experimental software disclaimer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # Hypercerts SDK
 
+> **⚠️ Experimental Software — Not for Production Use**
+>
+> This SDK is experimental and under active development. It should **not** be used in production environments. For
+> production use, please use the [ATProto SDK](https://github.com/bluesky-social/atproto/tree/main/packages) directly
+> and the [scaffold app](https://github.com/hypercerts-org/hypercerts-app) as a reference implementation.
+
 A monorepo containing SDK packages for the Hypercerts protocol on ATProto.
 
 ## Packages

--- a/packages/sdk-core/README.md
+++ b/packages/sdk-core/README.md
@@ -1,5 +1,11 @@
 # @hypercerts-org/sdk-core
 
+> **⚠️ Experimental Software — Not for Production Use**
+>
+> This SDK is experimental and under active development. It should **not** be used in production environments. For
+> production use, please use the [ATProto SDK](https://github.com/bluesky-social/atproto/tree/main/packages) directly
+> and the [scaffold app](https://github.com/hypercerts-org/hypercerts-app) as a reference implementation.
+
 Framework-agnostic ATProto SDK for Hypercerts. Create, manage, and collaborate on hypercerts using the AT Protocol.
 
 ```bash

--- a/packages/sdk-core/src/core/SDK.ts
+++ b/packages/sdk-core/src/core/SDK.ts
@@ -175,6 +175,13 @@ export class ATProtoSDK {
     // Initialize OAuth client
     this.oauthClient = new OAuthClient(configWithDefaults);
 
+    // Experimental software warning
+    console.warn(
+      "[@hypercerts-org/sdk-core] ⚠️ This SDK is experimental and should not be used in production. " +
+        "For production use, please use the ATProto SDK (https://github.com/bluesky-social/atproto) " +
+        "and the scaffold app (https://github.com/hypercerts-org/hypercerts-app).",
+    );
+
     this.logger?.info("ATProto SDK initialized");
   }
 

--- a/packages/sdk-react/README.md
+++ b/packages/sdk-react/README.md
@@ -1,5 +1,11 @@
 # @hypercerts-org/sdk-react
 
+> **⚠️ Experimental Software — Not for Production Use**
+>
+> This SDK is experimental and under active development. It should **not** be used in production environments. For
+> production use, please use the [ATProto SDK](https://github.com/bluesky-social/atproto/tree/main/packages) directly
+> and the [scaffold app](https://github.com/hypercerts-org/hypercerts-app) as a reference implementation.
+
 React hooks and components for the Hypercerts ATProto SDK.
 
 ```bash


### PR DESCRIPTION
## Summary

Adds a prominent disclaimer across the SDK that this is **experimental software** and should not be used in production.

### Changes

- **Root README.md** — Added warning banner at the top
- **sdk-core README.md** — Added warning banner at the top  
- **sdk-react README.md** — Added warning banner at the top
- **SDK runtime** — Added `console.warn()` on SDK instantiation so developers see the warning at runtime

### Disclaimer text

> ⚠️ **Experimental Software — Not for Production Use**
>
> This SDK is experimental and under active development. It should **not** be used in production environments. For production use, please use the [ATProto SDK](https://github.com/bluesky-social/atproto/tree/main/packages) directly and the [scaffold app](https://github.com/hypercerts-org/hypercerts-app) as a reference implementation.

### Testing

- ✅ Build passes (`pnpm build`)
- ✅ All sdk-core tests pass (790/790)
- ✅ Lint passes (`pnpm lint`)
- ⚠️ Pre-existing sdk-react test failures (unrelated `localStorage.clear` issue)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added experimental software warnings across package documentation and SDK initialization, advising against production use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->