### PR TITLE
[HYPER-260] add maintenance notice to README and AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,8 @@
 > This SDK is **currently unmaintained** while the Hypercerts core development team focuses on higher-priority matters,
 > and **should not be used**. It is currently out of sync with the
 > [`@hypercerts-org/lexicon`](https://www.npmjs.com/package/@hypercerts-org/lexicon) package and is likely to break when
-> creating or updating Hypercerts records on ATProto. We plan to resume work on it in the next few months.
+> creating or updating Hypercerts records on ATProto. We'll reassess it over the coming months, informed by developer
+> feedback and developments in AI.
 >
 > In the meantime, we recommend using the
 > [`@hypercerts-org/lexicon`](https://www.npmjs.com/package/@hypercerts-org/lexicon) package directly, along with the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,16 @@
 # AGENTS.MD - AI Agent Instructions for Hypercerts SDK
 
+> **⚠️ Not Currently Maintained — Do Not Use**
+>
+> This SDK is **currently unmaintained** while the Hypercerts core development team focuses on higher-priority matters,
+> and **should not be used**. It is currently out of sync with the
+> [`@hypercerts-org/lexicon`](https://www.npmjs.com/package/@hypercerts-org/lexicon) package and is likely to break when
+> creating or updating Hypercerts records on ATProto. We plan to resume work on it in the next few months.
+>
+> In the meantime, we recommend using the
+> [`@hypercerts-org/lexicon`](https://www.npmjs.com/package/@hypercerts-org/lexicon) package directly, along with the
+> official [AT Protocol SDK](https://github.com/bluesky-social/atproto) and related packages.
+
 This document provides instructions for AI agents working in the Hypercerts SDK repository.
 
 ## Project Overview

--- a/README.md
+++ b/README.md
@@ -1,10 +1,15 @@
 # Hypercerts SDK
 
-> **⚠️ Experimental Software — Not for Production Use**
+> **⚠️ Not Currently Maintained — Do Not Use**
 >
-> This SDK is experimental and under active development. It should **not** be used in production environments. For
-> production use, please use the [ATProto SDK](https://github.com/bluesky-social/atproto/tree/main/packages) directly
-> and the [scaffold app](https://github.com/hypercerts-org/hypercerts-app) as a reference implementation.
+> This SDK is **currently unmaintained** while the Hypercerts core development team focuses on higher-priority matters,
+> and **should not be used**. It is currently out of sync with the
+> [`@hypercerts-org/lexicon`](https://www.npmjs.com/package/@hypercerts-org/lexicon) package and is likely to break when
+> creating or updating Hypercerts records on ATProto. We plan to resume work on it in the next few months.
+>
+> In the meantime, we recommend using the
+> [`@hypercerts-org/lexicon`](https://www.npmjs.com/package/@hypercerts-org/lexicon) package directly, along with the
+> official [AT Protocol SDK](https://github.com/bluesky-social/atproto) and related packages.
 
 A monorepo containing SDK packages for the Hypercerts protocol on ATProto.
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@
 > This SDK is **currently unmaintained** while the Hypercerts core development team focuses on higher-priority matters,
 > and **should not be used**. It is currently out of sync with the
 > [`@hypercerts-org/lexicon`](https://www.npmjs.com/package/@hypercerts-org/lexicon) package and is likely to break when
-> creating or updating Hypercerts records on ATProto. We plan to resume work on it in the next few months.
+> creating or updating Hypercerts records on ATProto. We'll reassess it over the coming months, informed by developer
+> feedback and developments in AI.
 >
 > In the meantime, we recommend using the
 > [`@hypercerts-org/lexicon`](https://www.npmjs.com/package/@hypercerts-org/lexicon) package directly, along with the

--- a/packages/sdk-core/README.md
+++ b/packages/sdk-core/README.md
@@ -5,7 +5,8 @@
 > This SDK is **currently unmaintained** while the Hypercerts core development team focuses on higher-priority matters,
 > and **should not be used**. It is currently out of sync with the
 > [`@hypercerts-org/lexicon`](https://www.npmjs.com/package/@hypercerts-org/lexicon) package and is likely to break when
-> creating or updating Hypercerts records on ATProto. We plan to resume work on it in the next few months.
+> creating or updating Hypercerts records on ATProto. We'll reassess it over the coming months, informed by developer
+> feedback and developments in AI.
 >
 > In the meantime, we recommend using the
 > [`@hypercerts-org/lexicon`](https://www.npmjs.com/package/@hypercerts-org/lexicon) package directly, along with the

--- a/packages/sdk-core/README.md
+++ b/packages/sdk-core/README.md
@@ -1,10 +1,15 @@
 # @hypercerts-org/sdk-core
 
-> **⚠️ Experimental Software — Not for Production Use**
+> **⚠️ Not Currently Maintained — Do Not Use**
 >
-> This SDK is experimental and under active development. It should **not** be used in production environments. For
-> production use, please use the [ATProto SDK](https://github.com/bluesky-social/atproto/tree/main/packages) directly
-> and the [scaffold app](https://github.com/hypercerts-org/hypercerts-app) as a reference implementation.
+> This SDK is **currently unmaintained** while the Hypercerts core development team focuses on higher-priority matters,
+> and **should not be used**. It is currently out of sync with the
+> [`@hypercerts-org/lexicon`](https://www.npmjs.com/package/@hypercerts-org/lexicon) package and is likely to break when
+> creating or updating Hypercerts records on ATProto. We plan to resume work on it in the next few months.
+>
+> In the meantime, we recommend using the
+> [`@hypercerts-org/lexicon`](https://www.npmjs.com/package/@hypercerts-org/lexicon) package directly, along with the
+> official [AT Protocol SDK](https://github.com/bluesky-social/atproto) and related packages.
 
 Framework-agnostic ATProto SDK for Hypercerts. Create, manage, and collaborate on hypercerts using the AT Protocol.
 

--- a/packages/sdk-react/README.md
+++ b/packages/sdk-react/README.md
@@ -5,7 +5,8 @@
 > This SDK is **currently unmaintained** while the Hypercerts core development team focuses on higher-priority matters,
 > and **should not be used**. It is currently out of sync with the
 > [`@hypercerts-org/lexicon`](https://www.npmjs.com/package/@hypercerts-org/lexicon) package and is likely to break when
-> creating or updating Hypercerts records on ATProto. We plan to resume work on it in the next few months.
+> creating or updating Hypercerts records on ATProto. We'll reassess it over the coming months, informed by developer
+> feedback and developments in AI.
 >
 > In the meantime, we recommend using the
 > [`@hypercerts-org/lexicon`](https://www.npmjs.com/package/@hypercerts-org/lexicon) package directly, along with the

--- a/packages/sdk-react/README.md
+++ b/packages/sdk-react/README.md
@@ -1,10 +1,15 @@
 # @hypercerts-org/sdk-react
 
-> **⚠️ Experimental Software — Not for Production Use**
+> **⚠️ Not Currently Maintained — Do Not Use**
 >
-> This SDK is experimental and under active development. It should **not** be used in production environments. For
-> production use, please use the [ATProto SDK](https://github.com/bluesky-social/atproto/tree/main/packages) directly
-> and the [scaffold app](https://github.com/hypercerts-org/hypercerts-app) as a reference implementation.
+> This SDK is **currently unmaintained** while the Hypercerts core development team focuses on higher-priority matters,
+> and **should not be used**. It is currently out of sync with the
+> [`@hypercerts-org/lexicon`](https://www.npmjs.com/package/@hypercerts-org/lexicon) package and is likely to break when
+> creating or updating Hypercerts records on ATProto. We plan to resume work on it in the next few months.
+>
+> In the meantime, we recommend using the
+> [`@hypercerts-org/lexicon`](https://www.npmjs.com/package/@hypercerts-org/lexicon) package directly, along with the
+> official [AT Protocol SDK](https://github.com/bluesky-social/atproto) and related packages.
 
 React hooks and components for the Hypercerts ATProto SDK.
 


### PR DESCRIPTION
## Summary

- Replaces the existing "Experimental Software" banner in README.md with a stronger "Not Currently Maintained — Do Not Use" notice
- Adds the same maintenance notice to AGENTS.md so AI agents are aware of the project status
- Recommends using `@hypercerts-org/lexicon` and the official AT Protocol SDK directly in the meantime

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated top-level status notices across docs to “Not Currently Maintained — Do Not Use.”
  * Replaced prior experimental/production guidance with interim guidance recommending direct use of the @hypercerts-org/lexicon package alongside the official AT Protocol SDK and related packages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->